### PR TITLE
Use the official tomdoc.vim repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Optionally download one of the [releases](https://github.com/sheerun/vim-polyglo
 - [stylus](https://github.com/wavded/vim-stylus) (syntax, indent, ftplugin, ftdetect)
 - [textile](https://github.com/timcharper/textile.vim) (syntax, ftplugin, ftdetect)
 - [tmux](https://github.com/acustodioo/vim-tmux) (syntax, ftdetect)
-- [tomdoc](https://github.com/mutewinter/tomdoc.vim) (syntax)
+- [tomdoc](https://github.com/duwanis/tomdoc.vim) (syntax)
 - [vbnet](https://github.com/vim-scripts/vbnet.vim) (syntax)
 - [twig](https://github.com/beyondwords/vim-twig) (syntax, ftplugin, ftdetect)
 - [xls](https://github.com/vim-scripts/XSLT-syntax) (syntax)

--- a/after/syntax/coffee.vim
+++ b/after/syntax/coffee.vim
@@ -5,8 +5,7 @@
 "
 
 syn keyword tomdocKeywords Returns containedin=coffeeComment contained
-syn keyword tomdocKeywords Yields containedin=coffeeComment contained
-syn keyword tomdocKeywords Raises containedin=coffeeComment contained
+syn keyword tomdocKeywords Throws containedin=coffeeComment contained
 syn keyword tomdocKeywords Examples containedin=coffeeComment contained
 syn keyword tomdocKeywords Signature containedin=coffeeComment contained
 
@@ -16,6 +15,6 @@ syn match tomdocDescriptions +\s*Public:+he=e-1 containedin=coffeeComment contai
 syn match tomdocDescriptions +\s*Internal:+he=e-1 containedin=coffeeComment contained
 syn match tomdocDescriptions +\s*Deprecated:+he=e-1 containedin=coffeeComment contained
 
-hi default link tomdocDescriptions TODO
-hi default link tomdocKeywords TODO
+hi default link tomdocDescriptions String
+hi default link tomdocKeywords String
 hi default link tomdocArguments HELP

--- a/after/syntax/ruby.vim
+++ b/after/syntax/ruby.vim
@@ -15,6 +15,6 @@ syn match tomdocDescriptions +\s*Public:+he=e-1 containedin=rubyComment containe
 syn match tomdocDescriptions +\s*Internal:+he=e-1 containedin=rubyComment contained
 syn match tomdocDescriptions +\s*Deprecated:+he=e-1 containedin=rubyComment contained
 
-hi default link tomdocDescriptions TODO
-hi default link tomdocKeywords TODO
+hi default link tomdocDescriptions String
+hi default link tomdocKeywords String
 hi default link tomdocArguments HELP


### PR DESCRIPTION
https://github.com/duwanis/tomdoc.vim is the offical tomdoc.vim repo, and has a few extra changes in it that mutewinter's fork does not. This commit adjusts the readme and updates the after/coffee.vim and after/ruby.vim files to reflect the latest changes for this plugin.
