### PR TITLE
Changed to dockerfile.vim included in Docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Optionally download one of the [releases](https://github.com/sheerun/vim-polyglo
 - [css](https://github.com/JulesWang/css.vim) (syntax)
 - [csv](https://github.com/chrisbra/csv.vim) (syntax, ftplugin, ftdetect)
 - [cucumber](https://github.com/tpope/vim-cucumber) (syntax, indent, compiler, ftplugin, ftdetect)
-- [dockerfile](https://github.com/honza/dockerfile.vim) (syntax, ftdetect)
+- [dockerfile](https://github.com/docker/docker) (syntax, ftdetect)
 - [elixir](https://github.com/elixir-lang/vim-elixir) (syntax, indent, compiler, ftplugin, ftdetect)
 - [emberscript](https://github.com/heartsentwined/vim-ember-script) (syntax, indent, ftplugin, ftdetect)
 - [emblem](https://github.com/heartsentwined/vim-emblem) (syntax, indent, ftplugin, ftdetect)

--- a/build
+++ b/build
@@ -23,17 +23,18 @@ extract() {
     path="$(printf "$pack" | cut -d ':' -f 2)"
     dir="tmp/$(printf "$path" | cut -d '/' -f 2)"
     directories="DIRS$(printf "$pack" | cut -d ':' -f 3)"
+    subtree="$(printf "$pack" | cut -d ':' -f 4)"
     printf -- "- [$name](https://github.com/$path) ("
 
     subdirs=""
     for subdir in ${!directories}; do
-      if [ -d "$dir/$subdir" ]; then
+      if [ -d "${dir}${subtree:-/}${subdir}" ]; then
         base="$(basename "$subdir")"
         if [[ "$subdirs" != *"$base"* ]]; then
           subdirs="$subdirs, $base"
         fi
 
-        copy_dir "$dir" "$subdir"
+        copy_dir "${dir}${subtree}" "$subdir"
       fi
     done
 
@@ -45,8 +46,9 @@ extract() {
     name="$(printf "$pack" | cut -d ':' -f 1)"
     path="$(printf "$pack" | cut -d ':' -f 2)"
     dir="tmp/$(printf "$path" | cut -d '/' -f 2)"
+    subtree="$(printf "$pack" | cut -d ':' -f 4)"
 
-    if [ -d "$dir/plugin" ]; then
+    if [ -d "$dir${subtree:-/}plugin" ]; then
       printf "Possible error (plugin directory exists): $path\n"
     fi
   done
@@ -78,7 +80,7 @@ PACKS="
   css:JulesWang/css.vim
   csv:chrisbra/csv.vim
   cucumber:tpope/vim-cucumber
-  dockerfile:honza/dockerfile.vim
+  dockerfile:docker/docker::/contrib/syntax/vim/
   elixir:elixir-lang/vim-elixir
   emberscript:heartsentwined/vim-ember-script
   emblem:heartsentwined/vim-emblem

--- a/syntax/dockerfile.vim
+++ b/syntax/dockerfile.vim
@@ -7,10 +7,11 @@ if exists("b:current_syntax")
     finish
 endif
 
+let b:current_syntax = "dockerfile"
+
 syntax case ignore
 
-syntax match dockerfileKeyword /\v^\s*(FROM|MAINTAINER|RUN|CMD|EXPOSE|ENV|ADD)\s/
-syntax match dockerfileKeyword /\v^\s*(ENTRYPOINT|VOLUME|USER|WORKDIR)\s/
+syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY)\s/
 highlight link dockerfileKeyword Keyword
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/
@@ -19,13 +20,4 @@ highlight link dockerfileString String
 syntax match dockerfileComment "\v^\s*#.*$"
 highlight link dockerfileComment Comment
 
-syntax include @DockerSh syntax/sh.vim
-try
-  syntax include @DockerSh after/syntax/sh.vim
-catch
-endtry
-
-syntax region dockerShSnip matchgroup=DockerShGroup start="^\s*\%(RUN\|CMD\)\s\+" end="$" contains=@DockerSh
-highlight link DockerShGroup dockerfileKeyword
-
-let b:current_syntax = "dockerfile"
+set commentstring=#\ %s


### PR DESCRIPTION
- Added syntax for specifying subtree location.
  - Add subtree location as a fourth colon separated value in PACKS e.g. `dockerfile:docker/docker::/contrib/syntax/vim/`
- Fetching dockerfile.vim from docker project.
- **NOTE** This might be on its way to Vim proper:
  https://groups.google.com/forum/#!topic/vim_dev/70768C8wxf4
