### PR TITLE
Switches JSON provider so quotes can be shown

### DIFF
--- a/build
+++ b/build
@@ -93,7 +93,7 @@ PACKS="
   jade:digitaltoad/vim-jade
   jasmine:glanotte/vim-jasmine
   javascript:pangloss/vim-javascript
-  json:sheerun/vim-json
+  json:elzr/vim-json
   jst:briancollins/vim-jst
   latex:LaTeX-Box-Team/LaTeX-Box
   less:groenewege/vim-less


### PR DESCRIPTION
I propose switching the current JSON syntax repo to this: https://github.com/elzr/vim-json

I have an issue with how the current JSON library hides quotes around strings unless hovered over. This breaks the behavior of `A` among other things. This library allows you to turn this off by setting:

```vim
let g:vim_json_syntax_conceal = 0
```