### PR TITLE
rust repository url updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Optionally download one of the [releases](https://github.com/sheerun/vim-polyglo
 - [r-lang](https://github.com/vim-scripts/R.vim) (syntax, ftplugin)
 - [rspec](https://github.com/sheerun/rspec.vim) (syntax, ftdetect)
 - [ruby](https://github.com/vim-ruby/vim-ruby) (syntax, indent, compiler, autoload, ftplugin, ftdetect)
-- [rust](https://github.com/wting/rust.vim) (syntax, indent, compiler, autoload, ftplugin, ftdetect)
+- [rust](https://github.com/rust-lang/rust.vim) (syntax, indent, compiler, autoload, ftplugin, ftdetect)
 - [sbt](https://github.com/derekwyatt/vim-sbt) (syntax, ftdetect)
 - [scala](https://github.com/derekwyatt/vim-scala) (syntax, indent, compiler, ftplugin, ftdetect)
 - [slim](https://github.com/slim-template/vim-slim) (syntax, indent, ftdetect)

--- a/build
+++ b/build
@@ -146,7 +146,7 @@ PACKS="
   r-lang:vim-scripts/R.vim
   rspec:sheerun/rspec.vim
   ruby:vim-ruby/vim-ruby
-  rust:wting/rust.vim
+  rust:rust-lang/rust.vim
   sbt:derekwyatt/vim-sbt
   scala:derekwyatt/vim-scala
   slim:slim-template/vim-slim


### PR DESCRIPTION
[old repo](https://github.com/wting/rust.vim) was moved to [rust-lang group](https://github.com/rust-lang/rust.vim) few months ago.