### PR TITLE
Use updated Swift plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Optionally download one of the [releases](https://github.com/sheerun/vim-polyglo
 - [slim](https://github.com/slim-template/vim-slim) (syntax, indent, ftdetect)
 - [solidity](https://github.com/ethereum/vim-solidity) (syntax, indent, ftdetect)
 - [stylus](https://github.com/wavded/vim-stylus) (syntax, indent, ftplugin, ftdetect)
-- [swift](https://github.com/toyamarinyon/vim-swift) (syntax, indent, ftdetect)
+- [swift](https://github.com/keith/swift.vim) (syntax, indent, ftplugin, ftdetect)
 - [systemd](https://github.com/kurayama/systemd-vim-syntax) (syntax, ftdetect)
 - [textile](https://github.com/timcharper/textile.vim) (syntax, ftplugin, ftdetect)
 - [thrift](https://github.com/solarnz/thrift.vim) (syntax, ftdetect)

--- a/build
+++ b/build
@@ -152,7 +152,7 @@ PACKS="
   slim:slim-template/vim-slim
   solidity:ethereum/vim-solidity
   stylus:wavded/vim-stylus
-  swift:toyamarinyon/vim-swift
+  swift:keith/swift.vim
   systemd:kurayama/systemd-vim-syntax
   textile:timcharper/textile.vim
   thrift:solarnz/thrift.vim


### PR DESCRIPTION
The current Swift package hasn't been updated in a year, lacks Swift 2.0 support, has incorrect syntax highlighting, and has glitchy indentation. https://github.com/keith/swift.vim seems to work better and is still maintained.