### PR TITLE
Use SVG for travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vim-polyglot [![Build Status][travis-img-url]][travis-url]
 
-[travis-img-url]: https://travis-ci.org/sheerun/vim-polyglot.png
+[travis-img-url]: https://travis-ci.org/sheerun/vim-polyglot.svg
 [travis-url]: https://travis-ci.org/sheerun/vim-polyglot
 
 A collection of language packs for Vim.


### PR DESCRIPTION
SVG badge are lighter and have a nicer rendering, expecially on retina display.