### PR TITLE
Make syntax concealing optional for JSON + Markdown.

### DIFF
--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -14,12 +14,17 @@ if !exists("main_syntax")
   let main_syntax = 'json'
 endif
 
+let s:concealends = ''
+if has('conceal') && get(g:, 'vim_json_syntax_conceal', 1) == 1
+  let s:concealends = ' concealends'
+endif
+
 syntax match   jsonNoise           /\%(:\|,\)/
 
 " Syntax: Strings
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
-syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
+exe 'syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ ' . s:concealends . ' contains=jsonEscape contained'
 
 " Syntax: JSON does not allow strings with single quotes, unlike JavaScript.
 syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -83,7 +83,10 @@ syn region markdownLink matchgroup=markdownLinkDelimiter start="(" end=")" conta
 syn region markdownId matchgroup=markdownIdDelimiter start="\[" end="\]" keepend contained
 syn region markdownAutomaticLink matchgroup=markdownUrlDelimiter start="<\%(\w\+:\|[[:alnum:]_+-]\+@\)\@=" end=">" keepend oneline
 
-let s:concealends = has('conceal') ? ' concealends' : ''
+let s:concealends = ''
+if has('conceal') && get(g:, 'vim_markdown_syntax_conceal', 1) == 1
+  let s:concealends = ' concealends'
+endif
 exe 'syn region markdownItalic matchgroup=markdownItalicDelimiter start="\S\@<=\*\|\*\S\@=" end="\S\@<=\*\|\*\S\@=" keepend contains=markdownLineStart' . s:concealends
 exe 'syn region markdownItalic matchgroup=markdownItalicDelimiter start="\S\@<=_\|_\S\@=" end="\S\@<=_\|_\S\@=" keepend contains=markdownLineStart' . s:concealends
 exe 'syn region markdownBold matchgroup=markdownBoldDelimiter start="\S\@<=\*\*\|\*\*\S\@=" end="\S\@<=\*\*\|\*\*\S\@=" keepend contains=markdownLineStart,markdownItalic' . s:concealends


### PR DESCRIPTION
Allow users to toggle concealing off for JSON and Markdown using the following new options:

```viml
" turn off JSON conceal *mirrors vim-json's setting
let g:vim_json_syntax_conceal = 0

" turn off Markdown conceal
let g:vim_markdown_syntax_conceal = 0
```

Default is on, so should have the same expected behavior OOB. I can add more options for other languages, but these were the 2 that affected me personally.