### PR TITLE
Support for OpenSCAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Optionally download one of the [releases](https://github.com/sheerun/vim-polyglo
 - [ocaml](https://github.com/jrk/vim-ocaml) (syntax, indent, ftplugin)
 - [octave](https://github.com/vim-scripts/octave.vim--) (syntax)
 - [opencl](https://github.com/petRUShka/vim-opencl) (syntax, indent, ftplugin, ftdetect)
+- [openscad](https://github.com/sirtaj/vim-openscad) (syntax, ftplugin, ftdetect)
 - [perl](https://github.com/vim-perl/vim-perl) (syntax, indent, ftplugin, ftdetect)
 - [pgsql](https://github.com/exu/pgsql.vim) (syntax, ftdetect)
 - [php](https://github.com/StanAngeloff/php.vim) (syntax)

--- a/ftdetect/polyglot.vim
+++ b/ftdetect/polyglot.vim
@@ -316,6 +316,9 @@ if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'opencl') == -1
   
 au! BufRead,BufNewFile *.cl set filetype=opencl
 endif
+
+au! BufRead,BufNewFile *.scad set filetype=openscad
+
 if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'perl') == -1
   
 function! s:DetectPerl6()

--- a/ftplugin/openscad.vim
+++ b/ftplugin/openscad.vim
@@ -1,0 +1,2 @@
+au BufRead,BufNewFile *.scad    setfiletype openscad
+an 50.80.265 &Syntax.NO.OpenSCAD :cal SetSyn("openscad")<CR>

--- a/syntax/openscad.vim
+++ b/syntax/openscad.vim
@@ -1,0 +1,77 @@
+if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'c/c++') == -1
+
+" Vim syntax file
+" Language:     OpenSCAD
+" Maintainer:   Sirtaj Singh Kang <sirtaj-vim@sirtaj.net>
+" Last Changed: 2011 April 19
+
+if version < 600
+    syntax clear
+elseif exists("b:current_syntax")
+    finish
+endif
+
+
+"syn keyword openscadFunctionDef function
+syn keyword openscadFunctionDef function nextgroup=openscadFunction skipwhite skipempty
+syn match openscadFunction /\<\h\w*\>/ contained display
+
+"syn keyword openscadModuleDef module
+syn keyword openscadModuleDef module nextgroup=openscadModule skipwhite skipempty
+syn match openscadModule /\<\h\w*\>/ contained display
+
+syn keyword openscadStatement echo assign
+syn keyword openscadConditional if else
+syn keyword openscadRepeat for intersection_for
+syn keyword openscadInclude include use
+syn keyword openscadCsgKeyword union difference intersection render intersection_for
+syn keyword openscadTransform scale rotate translate mirror multmatrix color minkowski 
+syn keyword openscadPrimitiveSolid cube sphere cylinder polyhedron surface
+
+syn match openscadSpecialVariable "\$[a-zA-Z]\+\>" display
+syn match openscadModifier "^\s*[\*\!\#\%]" display
+
+syn match openscadNumbers "\<\d\|\.\d" contains=openscadNumber display transparent
+syn match openscadNumber "\d\+" display contained 
+syn match openscadNumber "\.\d\+" display contained 
+
+syn region openscadString start=/"/ skip=/\\"/ end=/"/
+
+syn keyword openscadBoolean true false
+
+syn keyword openscadCommentTodo TODO FIXME XXX contained display
+syn match openscadInlineComment ://.*$: contains=scadCommentTodo
+syn region openscadBlockComment start=:/\*: end=:\*/: fold contains=openscadCommentTodo
+
+syn region openscadBlock start="{" end="}" transparent fold
+syn region openscadVector start="\[" end="\]" transparent fold
+
+syn keyword openscadBuiltin abs acos asin atan atan2 ceil cos exp floor ln log
+syn keyword openscadBuiltin lookup max min pow rands round sign sin sqrt tan
+syn keyword openscadBuiltin str 
+
+hi def link openscadFunctionDef			Structure
+hi def link openscadFunction			Function
+hi def link openscadModuleDef			Structure
+hi def link openscadModule			    Function
+hi def link openscadBlockComment		Comment
+hi def link openscadBoolean			    Boolean
+hi def link openscadBuiltin			    Function
+hi def link openscadConditional			Conditional
+hi def link openscadCsgKeyword			Structure
+hi def link openscadInclude			    Include
+hi def link openscadInlineComment	    Comment
+hi def link openscadModifier			Special
+hi def link openscadStatement			Statement
+hi def link openscadNumbers			    Number
+hi def link openscadNumber			    Number
+hi def link openscadPrimitiveSolid		Keyword
+hi def link openscadRepeat			    Repeat
+hi def link openscadSpecialVariable		Special
+hi def link openscadString			    String
+hi def link openscadTransform			Statement
+hi def link openscadCommentTodo			Todo
+
+let b:current_syntax = "openscad"
+
+endif

--- a/syntax/openscad.vim
+++ b/syntax/openscad.vim
@@ -1,4 +1,4 @@
-if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'c/c++') == -1
+if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'openscad') == -1
 
 " Vim syntax file
 " Language:     OpenSCAD


### PR DESCRIPTION
I use OpenSCAD a lot. Made sense to include it here. 

Credits included. I did not write the syntax. They are all directly from sirtaj/vim-openscad; only change is the `exists(g:polyglot_disabled)` flag (wrapper?) in syntax/openscad.vim