### PR TITLE
readability: add newline and comment to generated ftdetect file

### DIFF
--- a/build
+++ b/build
@@ -75,7 +75,7 @@ copy_dir() {
 }
 
 concat_ftdetect() {
-  cat ftdetect/* | grep -E '^[^"]' > tmp/polyglot.vim
+  for f in ftdetect/*; do (echo '" '"$f"; cat "${f}"; echo) >> tmp/polyglot.vim; done
   rm -f ftdetect/*
   mv tmp/polyglot.vim ftdetect/
 }


### PR DESCRIPTION
`ftdetect/polyglot.vim`

Before

```vim
if !exists('foo')

" foo ftdetect content

endif
if !exists('bar')

" bar ftdetect content

endif
```

After

```vim
" ftdetect/foo.vim
if !exists('foo')

" foo ftdetect content

endif

" ftdetect/bar.vim
if !exists('bar')

" bar ftdetect content

endif
```