### PR TITLE
Wrap ftdetect blocks in augroup

### DIFF
--- a/build
+++ b/build
@@ -77,7 +77,14 @@ copy_dir() {
 
 concat_ftdetect() {
   cat config.vim >> tmp/polyglot.vim
-  for f in ftdetect/*; do (echo '" '"$f"; cat "${f}"; echo) >> tmp/polyglot.vim; done
+  for f in ftdetect/*; do
+    (
+      echo "augroup filetypedetect";
+      echo '" '"$f"; cat "${f}";
+      echo "augroup END";
+      echo
+    ) >> tmp/polyglot.vim;
+  done
   rm -f ftdetect/*
   mv tmp/polyglot.vim ftdetect/
 }


### PR DESCRIPTION
When `Hexplore` or `Vexplore` is called the current buffer loses its
syntax highlighting if it's provided by polyglot.

This wraps each ftdetect block in an `augroup` which resolves the issue.

The solution was taken from https://github.com/junegunn/vim-plug/issues/474

Should resolve #153 
