### PR TITLE
Allowed for more flexible custom HTML tag names

### DIFF
--- a/syntax/html.vim
+++ b/syntax/html.vim
@@ -68,7 +68,7 @@ syn keyword htmlTagName contained span subset sum tan tanh tendsto times transpo
 syn keyword htmlTagName contained uplimit variance vector vectorproduct xor
 
 " Custom Element
-syn match htmlTagName contained "\<[a-z_]\([a-z0-9_.]\+\)\?\(\-[a-z0-9_.]\+\)\+\>"
+syn match htmlTagName contained "\<[a-z_]\(-\?[a-z0-9_]\)\+\>"
 
 " HTML 5 arguments
 " Core Attributes


### PR DESCRIPTION
When trying out the syntax highlighting with this plugin, I found that it didn't highlight custom tags that didn't have a dash `-` in them. Pretty much all front-end libraries allow developers to create custom components with no `-` in them, which makes this a frustrating problem.

 This change to the `htmlTagName` regex should fix this issue.