### PR TITLE
Change of defmodule color

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -184,7 +184,7 @@ hi def link elixirExceptionDefine        Define
 hi def link elixirCallbackDefine         Define
 hi def link elixirStructDefine           Define
 hi def link elixirExUnitMacro            Define
-hi def link elixirModuleDeclaration      Type
+hi def link elixirModuleDeclaration      Identifier
 hi def link elixirFunctionDeclaration    Function
 hi def link elixirMacroDeclaration       Macro
 hi def link elixirInclude                Include


### PR DESCRIPTION
Change color of "defmodule" to "Indentifier" to make module name distinguishable from "defmodule" and "do" keywords. 
As in issue [#179](https://github.com/sheerun/vim-polyglot/issues/179).

Before:

<img width="633" alt="zrzut ekranu 2017-01-26 16 39 51" src="https://cloud.githubusercontent.com/assets/7414533/22337915/63f81a4a-e3e6-11e6-922c-e1dc02c2be97.png">

After:

<img width="682" alt="zrzut ekranu 2017-02-02 11 14 53" src="https://cloud.githubusercontent.com/assets/7414533/22545403/e83320f0-e938-11e6-89cf-48a7a49ffe3f.png">

