### PR TITLE
Add vifm syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ If you need full functionality of any plugin, please use it directly with your p
 - [vala](https://github.com/arrufat/vala.vim) (syntax, indent)
 - [vbnet](https://github.com/vim-scripts/vbnet.vim) (syntax)
 - [vcl](https://github.com/smerrill/vcl-vim-plugin) (syntax)
+- [vifm](https://github.com/vifm/vifm.vim) (syntax)
 - [vm](https://github.com/lepture/vim-velocity) (syntax, indent)
 - [vue](https://github.com/posva/vim-vue) (syntax, indent, ftplugin)
 - [xls](https://github.com/vim-scripts/XSLT-syntax) (syntax)

--- a/build
+++ b/build
@@ -206,6 +206,7 @@ PACKS="
   vala:arrufat/vala.vim
   vbnet:vim-scripts/vbnet.vim
   vcl:smerrill/vcl-vim-plugin
+  vifm:vifm/vifm.vim
   vue:posva/vim-vue
   vm:lepture/vim-velocity
   xls:vim-scripts/XSLT-syntax


### PR DESCRIPTION
Originally from: https://github.com/vifm/vifm.vim/blob/master/syntax/vifm.vim

Tested by running the build script once.