### PR TITLE
Add autohotkey

### DIFF
--- a/build
+++ b/build
@@ -110,6 +110,7 @@ PACKS="
   apiblueprint:sheerun/apiblueprint.vim
   applescript:vim-scripts/applescript.vim
   asciidoc:asciidoc/vim-asciidoc
+  autohotkey:hnamikaw/vim-autohotkey
   yaml:stephpy/vim-yaml
   ansible:pearofducks/ansible-vim
   arduino:sudar/vim-arduino-syntax


### PR DESCRIPTION
Add autohotkey to build script. Did not invoke build because it does
massive changes that bury this change in noise.

Vim comes with autohotkey syntax, but not indent. This plugin provides
indenting.