### PR TITLE
Update Solidity language pack repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If you need full functionality of any plugin, please use it directly with your p
 - [scala](https://github.com/derekwyatt/vim-scala) (syntax, indent, compiler, ftplugin)
 - [scss](https://github.com/cakebaker/scss-syntax.vim) (syntax, autoload, ftplugin)
 - [slim](https://github.com/slim-template/vim-slim) (syntax, indent, ftplugin)
-- [solidity](https://github.com/ethereum/vim-solidity) (syntax, indent)
+- [solidity](https://github.com/tomlion/vim-solidity) (syntax, indent, ftplugin)
 - [stylus](https://github.com/wavded/vim-stylus) (syntax, indent, ftplugin)
 - [swift](https://github.com/keith/swift.vim) (syntax, indent, ftplugin)
 - [sxhkd](https://github.com/baskerville/vim-sxhkdrc) (syntax)

--- a/build
+++ b/build
@@ -190,7 +190,7 @@ PACKS="
   scala:derekwyatt/vim-scala
   scss:cakebaker/scss-syntax.vim
   slim:slim-template/vim-slim
-  solidity:ethereum/vim-solidity
+  solidity:tomlion/vim-solidity
   stylus:wavded/vim-stylus
   swift:keith/swift.vim
   sxhkd:baskerville/vim-sxhkdrc


### PR DESCRIPTION
The old repo for Solidity was outdated, I have switched Polyglot to use the official recommendation from the ethereum foundation (found here: https://solidity.readthedocs.io/en/develop/#available-solidity-integrations).