### PR TITLE
autoload/vital/crystal.vital file is required for :Crystal* commands

### DIFF
--- a/autoload/vital/crystal.vital
+++ b/autoload/vital/crystal.vital
@@ -1,0 +1,6 @@
+crystal
+a977489
+
+Process
+Web.JSON
+ColorEcho


### PR DESCRIPTION
crystal_lang.vim calls vital#of('crystal').

vital#of('crystal') looks for crystal.vital file. Without this file, it throws an error and all the juicy :CrystalFormat, :CrystalImpl, crystal_lang#complete commands and omnifunction throw errors.