### PR TITLE
Add `pandoc`

### DIFF
--- a/build
+++ b/build
@@ -178,6 +178,7 @@ PACKS="
   ocaml:jrk/vim-ocaml
   octave:vim-scripts/octave.vim--
   opencl:petRUShka/vim-opencl
+  pandoc:vim-pandoc/vim-pandoc-syntax
   perl:vim-perl/vim-perl
   pgsql:exu/pgsql.vim
   php:StanAngeloff/php.vim

--- a/config.vim
+++ b/config.vim
@@ -16,6 +16,8 @@ augroup END
 
 let g:python_highlight_all = 1
 
+let g:vim_pandoc_syntax_exists = 1
+
 augroup filetypedetect
   if v:version < 704
     " NOTE: this line fixes an issue with the default system-wide lisp ftplugin


### PR DESCRIPTION
The pandoc syntax bundle contains a one-line plugin; it looks like the
convention is to set these sorts of variables in `config.vim`, so I've done
that here.