### PR TITLE
Update applescript to one that provides ftdetect

### DIFF
--- a/build
+++ b/build
@@ -114,7 +114,7 @@ EOF
 
 PACKS="
   apiblueprint:sheerun/apiblueprint.vim
-  applescript:vim-scripts/applescript.vim
+  applescript:mityu/vim-applescript
   asciidoc:asciidoc/vim-asciidoc
   yaml:stephpy/vim-yaml
   ansible:pearofducks/ansible-vim


### PR DESCRIPTION
Current applescript defines a syntax file, but doesn't setup an
applescript filetype to apply the syntax.

This one does ftdetect, indent, and has some ftplugin for running
applescript through osascript.

It uses an identical syntax file to the existing one.