### PR TITLE
Increase test file parsing timeout

### DIFF
--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -11,7 +11,7 @@ describe "My Vim plugin" do
 
   extensions.each do |ext|
     it "should parse #{ext} file" do
-      Timeout::timeout(5) do
+      Timeout::timeout(15) do
         write_file "#{ext}", ""
         vim.edit "#{ext}"
         vim.insert "sample"


### PR DESCRIPTION
There's been several PRs that inexplicably failed tests.

PR #279 (applescript) failed with "should parse test.em file" despite
the exact same PR #286 passing (I've removed one of them, sorry again
about that).

PR #268 (pandoc) failed with "parse test.erb file" but doesn't mess with
eruby.

PR #281 (readme) failed with "should parse test.jsx file" but it's a one
word change to the readme!

My assumption is that vim startup on Travis is near the edge of the
timeout so we're getting false failures. (I'm not familiar with
Vimrunner or rspec, but I assume this code is just testing that vim
doesn't throw errors one edit and automatically exits at the end of the
block.)