### PR TITLE
Include `jsx` in filetype when extension is `tsx`

### DIFF
--- a/ftdetect/polyglot.vim
+++ b/ftdetect/polyglot.vim
@@ -23,7 +23,7 @@ augroup filetypedetect
     "       (*.jl files are recognized as lisp)
     autocmd BufRead,BufNewFile *.jl    let b:undo_ftplugin = "setlocal comments< define< formatoptions< iskeyword< lisp<"
   endif
-  
+
   autocmd BufRead,BufNewFile *.jl      set filetype=julia
 
   " coffeescript
@@ -49,7 +49,7 @@ augroup filetypedetect
                                \'',
                                \'end']) |
               \ 2
-  
+
   " git
   autocmd BufNewFile,BufRead *.git/{,modules/**/,worktrees/*/}{COMMIT_EDIT,TAG_EDIT,MERGE_,}MSG set ft=gitcommit
   autocmd BufNewFile,BufRead *.git/config,.gitconfig,gitconfig,.gitmodules set ft=gitconfig
@@ -300,7 +300,7 @@ endif
 if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'ferm') == -1
   augroup filetypedetect
   " ferm, from ferm.vim in vim-scripts/ferm.vim
-autocmd BufNewFile,BufRead ferm.conf setf ferm 
+autocmd BufNewFile,BufRead ferm.conf setf ferm
 autocmd BufNewFile,BufRead *.ferm setf ferm
   augroup end
 endif
@@ -1046,7 +1046,7 @@ if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'textile') == -1
 " Tim Harper (tim.theenchanter.com)
 
 " Force filetype to be textile even if already set
-" This will override the system ftplugin/changelog 
+" This will override the system ftplugin/changelog
 " set on some distros
 au BufRead,BufNewFile *.textile set filetype=textile
   augroup end
@@ -1092,7 +1092,7 @@ if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'typescript') ==
 " use `set filetype` to override default filetype=xml for *.ts files
 autocmd BufNewFile,BufRead *.ts  set filetype=typescript
 " use `setfiletype` to not override any other plugins like ianks/vim-tsx
-autocmd BufNewFile,BufRead *.tsx setfiletype typescript
+autocmd BufNewFile,BufRead *.tsx setfiletype typescript.jsx
   augroup end
 endif
 


### PR DESCRIPTION
Following the convention that the filetype for **.jsx** files is `javascript.jsx`, **.tsx** files should also include the `jsx` filetype.

This enables syntax highlighting for the JSX portion in **.tsx** files.

---

Follows https://github.com/leafgarland/typescript-vim/pull/140