### PR TITLE
add orgmode

### DIFF
--- a/build
+++ b/build
@@ -219,6 +219,7 @@ PACKS="
   ocaml:jrk/vim-ocaml
   octave:vim-scripts/octave.vim--
   opencl:petRUShka/vim-opencl
+  org:jceb/vim-orgmode
   perl:vim-perl/vim-perl
   pgsql:exu/pgsql.vim
   php:StanAngeloff/php.vim


### PR DESCRIPTION
It is only set for *.org files: https://github.com/jceb/vim-orgmode/blob/master/ftdetect/org.vim

What is orgmode? See http://orgmode.org

Why this repo? It is the most popular vim orgmode repo.