### PR TITLE
i3: Use i3config.vim instead of i3-vim-syntax (not maintained)

### DIFF
--- a/build
+++ b/build
@@ -194,7 +194,7 @@ PACKS="
   haskell:neovimhaskell/haskell-vim
   haxe:yaymukund/vim-haxe
   html5:othree/html5.vim
-  i3:PotatoesMaster/i3-vim-syntax
+  i3:mboughaba/i3config.vim
   jasmine:glanotte/vim-jasmine
   javascript:pangloss/vim-javascript:_JAVASCRIPT
   jenkins:martinda/Jenkinsfile-vim-syntax


### PR DESCRIPTION
More info in <https://github.com/mboughaba/i3config.vim#what-about-potatoesmasteri3-vim-syntax>