### PR TITLE
tmux: Use ericpruitt/tmux.vim instead of keith/tmux.vim (deprecated)

### DIFF
--- a/build
+++ b/build
@@ -252,7 +252,7 @@ PACKS="
   terraform:hashivim/vim-terraform
   textile:timcharper/textile.vim
   thrift:solarnz/thrift.vim
-  tmux:keith/tmux.vim
+  tmux:ericpruitt/tmux.vim
   tomdoc:wellbredgrapefruit/tomdoc.vim
   toml:cespare/vim-toml
   twig:lumiliet/vim-twig


### PR DESCRIPTION
More info in <https://github.com/keith/tmux.vim#deprecated>