### PR TITLE
Add puml as plantuml filetype

### DIFF
--- a/config.vim
+++ b/config.vim
@@ -59,7 +59,7 @@ augroup filetypedetect
   autocmd BufNewFile,BufRead .gitsendemail.*                               set ft=gitsendemail
 
   " plantuml
-  autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml setfiletype plantuml | set filetype=plantuml
+  autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml,*.puml setfiletype plantuml | set filetype=plantuml
 
   " scala
   au BufRead,BufNewFile *.scala,*.sc set filetype=scala

--- a/ftdetect/polyglot.vim
+++ b/ftdetect/polyglot.vim
@@ -59,7 +59,7 @@ augroup filetypedetect
   autocmd BufNewFile,BufRead .gitsendemail.*                               set ft=gitsendemail
 
   " plantuml
-  autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml setfiletype plantuml | set filetype=plantuml
+  autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml,*.puml setfiletype plantuml | set filetype=plantuml
 
   " scala
   au BufRead,BufNewFile *.scala,*.sc set filetype=scala


### PR DESCRIPTION
Added *.puml as plantuml filetype (this was originally added in the source plugin here https://github.com/aklt/plantuml-syntax/commit/a2a20b5052b00ae5d109709f3926d5b13b03359f).

Not sure about `config.vim` file, it seems the only part to get this working was `ftdetect/polyglot.vim`, but added the change also in `config.vim`.