### PR TITLE
[build] explicitly set locale to C when sorting

### DIFF
--- a/build
+++ b/build
@@ -130,7 +130,7 @@ update_readme() {
   local tf of
   tf="$(mktemp)"
   of="$(mktemp)"
-  sort <<<"$OUTPUT" | grep -vxE '[[:space:]]*' > "$of"
+  LC_ALL=C sort <<<"$OUTPUT" | grep -vxE '[[:space:]]*' > "$of"
 
   awk 'suppress == 0 {
       gsub(/<!--Package Count-->[^<]*<!--\/Package Count-->/,


### PR DESCRIPTION
Extremely simple PR here. 

All this does is sets the system's locale to `C` explicitly so that the sort function will sort the readme the exact same way on all systems.

Let me know if you have any questions....