### PR TITLE
Stop messing with ALE settings

### DIFF
--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -20,9 +20,4 @@ if !exists('g:no_plugin_maps') && !exists('g:no_vue_maps')
   nnoremap <silent> <buffer> ][ :call search('^</\(template\<Bar>script\<Bar>style\)', 'W')<CR>
 endif
 
-" Run only ESLint for Vue files by default.
-" linters specifically for Vue can still be loaded.
-let b:ale_linter_aliases = get(get(g:, 'ale_linter_aliases', {}), 'vue', ['vue', 'javascript'])
-let b:ale_linters = get(get(g:, 'ale_linters', {}), 'vue', ['eslint', 'vls'])
-
 endif


### PR DESCRIPTION
These variables are already set by the vim-vue plugin, and don't need to be set in any plugin really. Setting these settings here messes with settings that users want to set themselves.

See this issue: https://github.com/w0rp/ale/issues/2043