### PR TITLE
Add support for .cue files

### DIFF
--- a/build
+++ b/build
@@ -171,6 +171,7 @@ PACKS="
   crystal:rhysd/vim-crystal
   cql:elubow/cql-vim
   cucumber:tpope/vim-cucumber
+  cue:mgrabovsky/vim-cuesheet
   dart:dart-lang/dart-vim-plugin
   dockerfile:ekalinin/Dockerfile.vim
   elixir:elixir-lang/vim-elixir


### PR DESCRIPTION

1. How you chose the particular repo from which to pull support for this language.
    Compared the limited options:

    - https://github.com/vim-scripts/cue.vim
    - https://github.com/mgrabovsky/vim-cuesheet

    and decided that the latter was decidedly better.
2. <strike>An updated https://github.com/sheerun/vim-polyglot/blob/master/build . </strike>
3. <strike>If at all possible, absolutely nothing else (in particular, please don't run build and include that in your PR).</strike>


