### PR TITLE
fish: use standard shell definition of a keyword

### DIFF
--- a/ftplugin/fish.vim
+++ b/ftplugin/fish.vim
@@ -7,7 +7,6 @@ setlocal foldexpr=fish#Fold()
 setlocal formatoptions+=ron1
 setlocal formatoptions-=t
 setlocal include=\\v^\\s*\\.>
-setlocal iskeyword=@,48-57,-,_,.,/
 setlocal suffixesadd^=.fish
 
 " Use the 'j' format option when available.


### PR DESCRIPTION
This effectively removes "-", "." and "/" from the set of word characters.

Prior to this, a `w` would skip over the entirety of /some/really/long/path-name.
This is probably not what users expect, since they can use `W` for that.

I can see the point being able to move by precisely one fish identifier, but those are separated by blanks anyway, so `W` works.