### PR TITLE
Fix orgmode disabling

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -1,5 +1,7 @@
-if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'org') == -1
-  
+if exists('g:polyglot_disabled') && index(g:polyglot_disabled, 'org') != -1
+	finish
+endif
+
 " org.vim -- Text outlining and task management for Vim based on Emacs' Org-Mode
 " @Author       : Jan Christoph Ebersbach (jceb@e-jc.de)
 " @License      : AGPL3 (see http://www.gnu.org/licenses/agpl.txt)
@@ -169,5 +171,3 @@ fun CalendarAction(day, month, year, week, dir)
 	" restore calendar_action
 	let g:calendar_action = g:org_calendar_action_backup
 endf
-
-endif


### PR DESCRIPTION
Disabling orgmode in polyglot works, but gives an error meesage at vim
startup.

To disable orgmode, add this line in vimrc:
```
let g:polyglot_disabled = ['org']
```

It makes the file ftplugin/org.vim syntax wrong, producing this error
message:

```
Error detected while processing
.../.vim/plugged/vim-polyglot/ftplugin/org.vim:
line  174:
E171: Missing :endif
E171: Missing :endif
```

Fix #360