### PR TITLE
dockerfile: change package name to Dockerfile

### DIFF
--- a/build
+++ b/build
@@ -172,7 +172,7 @@ PACKS="
   cql:elubow/cql-vim
   cucumber:tpope/vim-cucumber
   dart:dart-lang/dart-vim-plugin
-  dockerfile:ekalinin/Dockerfile.vim
+  Dockerfile:ekalinin/Dockerfile.vim
   elixir:elixir-lang/vim-elixir
   elm:ElmCast/elm-vim
   emberscript:yalesov/vim-ember-script


### PR DESCRIPTION
Dockerfile syntax highlighting assumes that the Dockerfile sytax
plugin/filetype is set to "Dockerfile" which is the canonical name of
docker files not "dockerfile" which is the name created by the packge.
This causes all of the Dockerfile support to break for Dockerfiles
because the syntax and ftplugin names do not match ftdetect's filetype.

This patch addresses the issue by correctly capitalizing the Dockerfile
package, which will install the dockerfile plugins with the correct file
names.

NOTE: after this change configurations will need to enable/disable
"Dockerfile" instead of "dockerfile"

This addresses #361 at its root.