### PR TITLE
Add improved man ftplugin and command

### DIFF
--- a/build
+++ b/build
@@ -216,6 +216,7 @@ PACKS="
   livescript:gkz/vim-ls
   lua:tbastos/vim-lua
   mako:sophacles/vim-bundle-mako
+  man:gpanders/vim-man
   markdown:plasticboy/vim-markdown:_SYNTAX
   mathematica:rsmenon/vim-mathematica
   mdx:jxnblk/vim-mdx-js


### PR DESCRIPTION
This language pack improves on the default man.vim ftplugin by:

- Autoloading expensive functions
- Defining the `:Man` command at startup (and not when first visiting a man file)
- Not creating mappings by default

My motivation for creating this was wanting access to the `:Man` command but not liking the fact that running `runtime ftplugin/man.vim` in my startup process added almost 100ms to my startup time.

Link to repo: https://github.com/gpanders/vim-man