### PR TITLE
Fix jump to module in Elm 0.19

### DIFF
--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -136,7 +136,14 @@ function! elm#util#GoToModule(name)
 endfunction
 
 function! s:findLocalModule(rel_path, root)
-  let l:package_json = a:root . '/elm-package.json'
+  let l:old_match = findfile('elm-package.json', a:root . ';') " Elm 0.18
+  let l:new_match = findfile('elm.json', a:root . ';') " Elm 0.19
+  if !empty(l:new_match)
+    let l:package_json = l:new_match
+  elseif !empty(l:old_match)
+    let l:package_json = l:old_match
+  endif
+
   if exists('*json_decode')
     let l:package = json_decode(readfile(l:package_json))
     let l:source_roots = l:package['source-directories']
@@ -145,6 +152,7 @@ function! s:findLocalModule(rel_path, root)
     " It simply only looks in the 'src' subdirectory and fails otherwise.
     let l:source_roots = ['src']
   end
+
   for l:source_root in l:source_roots
     let l:file_path = a:root . '/' . l:source_root . '/' . a:rel_path
     if !filereadable(l:file_path)


### PR DESCRIPTION
Hi! Thanks for this wonderful plugin :)

I realized that jumping to a module using `gf` was not working for Elm 0.19 modules, so I've prepared a fix. You can test it out by creating a simple elm project with a module importing another module.