### PR TITLE
Add vim-xdc-syntax plugin

### DIFF
--- a/build
+++ b/build
@@ -276,7 +276,7 @@ PACKS="
   vifm:vifm/vifm.vim
   vm:lepture/vim-velocity
   vue:posva/vim-vue
-  xdc:gpanders/vim-xdc
+  xdc:amal-khailtash/vim-xdc-syntax
   xml:amadeus/vim-xml
   xls:vim-scripts/XSLT-syntax
   yaml:stephpy/vim-yaml

--- a/build
+++ b/build
@@ -276,6 +276,7 @@ PACKS="
   vifm:vifm/vifm.vim
   vm:lepture/vim-velocity
   vue:posva/vim-vue
+  xdc:gpanders/vim-xdc
   xml:amadeus/vim-xml
   xls:vim-scripts/XSLT-syntax
   yaml:stephpy/vim-yaml


### PR DESCRIPTION
This language pack provides syntax highlighting, filetype detection, and
a filetype plugin for Xilinx Vivado's Xilinx Design Constraints (XDC)
files, which is a superset of Tcl.

For the most part, [vim-xdc](https://github.com/gpanders/vim-xdc) simply sources the syntax and ftplugin files from Tcl and then adds a few other syntax highlighting commands on top of that. The biggest thing this provides from a functional standpoint is the filetype detection of *.xdc files.