### PR TITLE
Add HiveQL syntax highlight

### DIFF
--- a/build
+++ b/build
@@ -199,6 +199,7 @@ PACKS="
   haproxy:CH-DanReif/haproxy.vim
   haskell:neovimhaskell/haskell-vim
   haxe:yaymukund/vim-haxe
+  hive:zebradil/hive.vim
   html5:othree/html5.vim
   i3:mboughaba/i3config.vim
   idris:idris-hackers/idris-vim


### PR DESCRIPTION
There are some alternatives -- mainly forks of https://github.com/autowitch/hive.vim/network.
However, all of them are abandoned. The plugin I propose supports all the currently existing keywords of HiveQL and contains some advanced matching.