### PR TITLE
FIx CI build freezing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ addons:
     packages:
       - vim-gtk
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-script: bundle exec rspec --format=documentation
+  - "./build"
+script: xvfb-run bundle exec rspec --format=documentation

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -9,7 +9,7 @@ describe "My Vim plugin" do
 
   extensions = extensions.split(/[\n,]/)
 
-  extensions.each do |ext|
+  extensions.sort!.uniq!.each do |ext|
     if ext.match?(/^[a-z\.]+$/i)
       it "should parse #{ext} file" do
         Timeout::timeout(20) do

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -21,4 +21,6 @@ describe "My Vim plugin" do
       end
     end
   end
+
+  vim.kill
 end

--- a/spec/loading_spec.rb
+++ b/spec/loading_spec.rb
@@ -22,5 +22,7 @@ describe "My Vim plugin" do
     end
   end
 
-  vim.kill
+  after(:all) do
+    vim.kill
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'vimrunner/rspec'
 $plugin_path = File.expand_path('../..', __FILE__)
 
 Vimrunner::RSpec.configure do |config|
-  config.reuse_server = true
+  config.reuse_server = false
 
   # Decide how to start a Vim instance. In this block, an instance should be
   # spawned and set up with anything project-specific.


### PR DESCRIPTION
Fixes #380 

The key change here is restarting vim server for every file.
I also added execution of `build` script to be able to check PRs.

I tried different approaches: pure bash, vimrunner in python. They work pretty fast in comparison with the ruby version. Apart from that, I noticed that test actually doesn't check anything. If a *.vim file is corrupted, no error messages are displayed.