### PR TITLE
Use patched version of vim-fish

### DIFF
--- a/build
+++ b/build
@@ -183,7 +183,7 @@ PACKS="
   emblem:yalesov/vim-emblem
   erlang:vim-erlang/vim-erlang-runtime
   ferm:vim-scripts/ferm.vim
-  fish:dag/vim-fish
+  fish:georgewitteman/vim-fish
   flatbuffers:dcharbon/vim-flatbuffers
   fsharp:fsharp/vim-fsharp:_BASIC
   git:tpope/vim-git


### PR DESCRIPTION
Fish indentation was broken in the current version of vim-fish so I forked and fixed the indentation. I submitted a PR for the original repository but since it hasn't been updated since 2017 I'm changing vim-polyglot to use the version from my repository. It fixes the following issue:

![2019-06-03 23 10 02](https://user-images.githubusercontent.com/5918935/58930081-e606ad80-870e-11e9-8032-b41763b641c2.gif)
