### PR TITLE
add match_words from html to mako for tag matching

### DIFF
--- a/ftplugin/mako.vim
+++ b/ftplugin/mako.vim
@@ -13,3 +13,11 @@ let b:did_ftplugin = 1
 
 setlocal comments=:##
 setlocal commentstring=##%s
+
+if exists('loaded_matchit')
+    let b:match_ignorecase = 1
+    let b:match_words = '<:>,' .
+    \ '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' .
+    \ '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' .
+    \ '<\@<=\([^/][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+endif


### PR DESCRIPTION
matchit doesn't work for mako because `b:match_words` is not defined. I've added the same value here as HTML. If it needs to be different for some reason, let me know, but this seems to work pretty well so far.