### PR TITLE
Add Helm syntax

### DIFF
--- a/build
+++ b/build
@@ -203,6 +203,7 @@ PACKS="
   haskell:neovimhaskell/haskell-vim
   haxe:yaymukund/vim-haxe
   hcl:b4b4r07/vim-hcl
+  helm:towolf/vim-helm
   hive:zebradil/hive.vim
   html5:othree/html5.vim
   i3:mboughaba/i3config.vim


### PR DESCRIPTION
This is the only plugin which provides [Helm](https://helm.sh/) syntax highlighting I've found.