### PR TITLE
[Docker] Only spell check syntax marked with @Spell

### DIFF
--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -23,10 +23,12 @@ if version < 600
 endif
 syntax clear
 
+syntax spell notoplevel
+
 syn match yamlInline "[\[\]\{\}]"
 syn match yamlBlock "[>|]\d\?[+-]"
 
-syn region yamlComment	start="\#" end="$"
+syn region yamlComment	start="\#" end="$" contains=@Spell
 syn match yamlIndicator	"#YAML:\S\+"
 
 syn region yamlString	start="\(^\|\s\|\[\|\,\|\-\)\@<='" end="'" skip="\\'"

--- a/syntax/Dockerfile.vim
+++ b/syntax/Dockerfile.vim
@@ -15,6 +15,8 @@ endif
 " case sensitivity (fix #17)
 " syn case  ignore
 
+syntax spell notoplevel
+
 " Keywords
 syn keyword dockerfileKeywords FROM AS MAINTAINER RUN CMD COPY
 syn keyword dockerfileKeywords EXPOSE ADD ENTRYPOINT
@@ -46,7 +48,7 @@ syn keyword dockerfileTodo contained TODO FIXME XXX
 
 " Comments
 syn region dockerfileComment start="#" end="\n" contains=dockerfileTodo
-syn region dockerfileEnvWithComment start="^\s*ENV\>" end="\n" contains=dockerfileEnv
+syn region dockerfileEnvWithComment start="^\s*ENV\>" end="\n" contains=dockerfileEnv,@Spell
 syn match dockerfileEnv contained /\<ENV\>/
 
 " Highlighting

--- a/syntax/docker-compose.vim
+++ b/syntax/docker-compose.vim
@@ -14,13 +14,14 @@ endif
 
 " case sensitivity (fix #17)
 " syn case  ignore
+syntax spell notoplevel
 
 " Keywords
 syn keyword dockercomposeKeywords build context dockerfile args cap_add cap_drop
 syn keyword dockercomposeKeywords command cgroup_parent container_name devices depends_on
 syn keyword dockercomposeKeywords dns dns_search tmpfs entrypoint env_file environment
 syn keyword dockercomposeKeywords expose extends extends external_links extra_hosts
-syn keyword dockercomposeKeywords group_add image isolation labels links 
+syn keyword dockercomposeKeywords group_add image isolation labels links
 syn keyword dockercomposeKeywords log_opt net network_mode networks aliases
 syn keyword dockercomposeKeywords ipv4_address ipv6_address link_local_ips pid ports
 syn keyword dockercomposeKeywords security_opt stop_signal ulimits volumes volume_driver
@@ -69,7 +70,7 @@ syn match dockercomposeUrl /\(http\|https\|ssh\|hg\|git\)\:\/\/[a-zA-Z0-9\/\-\.]
 syn keyword dockercomposeTodo contained TODO FIXME XXX
 
 " Comments
-syn region dockercomposeComment start="#" end="\n" contains=dockercomposeTodo
+syn region dockercomposeComment start="#" end="\n" contains=dockercomposeTodo,@Spell
 
 " Highlighting
 hi link dockercomposeKeywords  Keyword


### PR DESCRIPTION
Before:

![2019-08-21_20-53-28](https://user-images.githubusercontent.com/2650040/63463787-cf423e00-c455-11e9-853f-87b7cc89a806.png)

![2019-08-24_20-14-11](https://user-images.githubusercontent.com/2650040/63641775-c9de3100-c6ab-11e9-8c32-c855dcb0d799.png)


After:

![2019-08-21_20-53-09](https://user-images.githubusercontent.com/2650040/63463832-e6812b80-c455-11e9-843a-eac609b99b7c.png)

![2019-08-24_20-13-47](https://user-images.githubusercontent.com/2650040/63641778-d4002f80-c6ab-11e9-8f87-874cd6ff219a.png)


Related PR: https://github.com/ekalinin/Dockerfile.vim/pull/64