### PR TITLE
Fix typescript indentation

### DIFF
--- a/after/indent/typescript.vim
+++ b/after/indent/typescript.vim
@@ -35,5 +35,3 @@ unlet s:keepcpo
 if exists('g:polyglot_disabled') && index(g:polyglot_disabled, 'styled-components') != -1
   finish
 endif
-
-runtime! indent/javascript.vim


### PR DESCRIPTION
After latest update I noticed that my `.ts` files were no longer indenting. 664aa988f6d9cdb7b75218666fbe348c85ef8b29 is the first commit that introdcues this behaviour.

Removing `runtime! indent/javascript.vim` from `indent/typescript.vim` seems to fix this issue although I'm not sure if it won't break anything else in the process as I'm not really familiar with vimscript.

I can provide more info if needed.