### PR TITLE
add two spaces to jsx tags

### DIFF
--- a/after/syntax/jsx_pretty.vim
+++ b/after/syntax/jsx_pretty.vim
@@ -135,7 +135,7 @@ exe 'syntax match jsxTagName
 "         ~~~~~~~~
 syntax region jsxString start=+\z(["']\)+  skip=+\\\%(\z1\|$\)+  end=+\z1+ contained contains=@Spell display
 
-let s:tags = get(g:, 'vim_jsx_pretty_template_tags', ['html', 'raw'])
+let s:tags = get(g:, 'vim_jsx_pretty_template_tags', ['html', 'raw', '  '])
 let s:enable_tagged_jsx = !empty(s:tags)
 
 " add support to JSX inside the tagged template string
@@ -149,12 +149,12 @@ if s:enable_tagged_jsx
         \ containedin=jsTemplateString,javascriptTemplate,javaScriptStringT,typescriptStringB
         \ contains=jsxElement'
 
-  syntax region jsxEscapeJs
-        \ start=+\${+
-        \ end=++
-        \ extend
-        \ contained
-        \ contains=jsTemplateExpression,javascriptTemplateSubstitution,javaScriptEmbed,typescriptInterpolation
+  "syntax region jsxEscapeJs
+  "      \ start=+\${+
+  "     \ end=++
+  "      \ extend
+  "      \ contained
+  "      \ contains=jsTemplateExpression,javascriptTemplateSubstitution,javaScriptEmbed,typescriptInterpolation
 
   syntax region jsxOpenTag
         \ matchgroup=jsxOpenPunct


### PR DESCRIPTION
I added a two spaces tag for jsx highlight in order to support native javascript template strings. Because both html and raw will produce an error since they are not defined functions