### PR TITLE
headsup on g:polyglot_disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Please make sure you have `syntax on` in your `.vimrc`, otherwise syntax files a
 Individual language packs can be disabled by setting `g:polyglot_disabled` as follows:
 
 ```viml
-" ~/.vimrc
+" ~/.vimrc, declare this variable before polyglot is loaded
 let g:polyglot_disabled = ['css']
 ```
 


### PR DESCRIPTION
I noticed that during [`ftdetect/polyglot.vim`](https://github.com/sheerun/vim-polyglot/blob/master/ftdetect/polyglot.vim#L574), the variable `g:polyglot_disabled` wasn't defined, even it's already declared in my `.vimrc`.

I'm not sure putting `g:polyglot_disabled` before polyglot load is a good practice, but if it's necessary, we should probably add some docs on this.