### PR TITLE
Add zinit syntax

### DIFF
--- a/build
+++ b/build
@@ -306,7 +306,7 @@ PACKS="
   yard:sheerun/vim-yardoc
   zephir:xwsoul/vim-zephir
   zig:ziglang/zig.vim
-  zplugin:zinit-zsh/zplugin-vim-syntax
+  zinit:zinit-zsh/zplugin-vim-syntax
 "
 
 rm -rf tmp

--- a/build
+++ b/build
@@ -306,6 +306,7 @@ PACKS="
   yard:sheerun/vim-yardoc
   zephir:xwsoul/vim-zephir
   zig:ziglang/zig.vim
+  zplugin:zinit-zsh/zplugin-vim-syntax
 "
 
 rm -rf tmp


### PR DESCRIPTION
https://github.com/zinit-zsh/zplugin-vim-syntax

This adds syntax for the zsh plugin manager zinit (formerly zplugin). This is the only plugin that exists for this syntax.