### PR TITLE
Combine ftdetect files in a predictable order

### DIFF
--- a/build
+++ b/build
@@ -72,8 +72,11 @@ extract() {
       continue
     fi
 
-    [ -d "${dir}${subtree:-/}ftdetect" ] && for f in "${dir}${subtree:-/}ftdetect/"*; do
-      cat <<EOF >> tmp/polyglot.vim
+    ftdetect=("${dir}${subtree:-/}ftdetect"/*)
+    if [ "$ftdetect" ] && [ "$ftdetect" != "${dir}${subtree:-/}ftdetect/*" ]; then
+      IFS=$'\n' ftdetect=($(sort -V <<< "${ftdetect[*]}")); unset IFS
+      for f in "${ftdetect[@]}"; do
+        cat <<EOF >> tmp/polyglot.vim
 if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, '${pack%%:*}') == -1
   augroup filetypedetect
   " ${pack%%:*}, from ${f##*/ftdetect/} in ${pack#*:}
@@ -82,7 +85,8 @@ $(cat "${f}")
 endif
 
 EOF
-    done
+      done
+    fi
 
   done
 


### PR DESCRIPTION
When I run `build` on my machine, I end up with hunks of moved code in `ftdetect/polyglot.vim`. For example,

```bash
diff -U1 \
 <( git show v4.2.0:ftdetect/polyglot.vim | grep -F ', from' ) \
 <( grep -F ', from' ftdetect/polyglot.vim )
```

```diff
@@ -19,9 +19,9 @@
   " dhall, from dhall.vim in vmchale/dhall-vim
-  " dlang, from d.vim in JesseKPhillips/d.vim
   " dlang, from dcov.vim in JesseKPhillips/d.vim
-  " dlang, from dd.vim in JesseKPhillips/d.vim
   " dlang, from ddoc.vim in JesseKPhillips/d.vim
+  " dlang, from dd.vim in JesseKPhillips/d.vim
   " dlang, from dsdl.vim in JesseKPhillips/d.vim
-  " dockerfile, from Dockerfile.vim in ekalinin/Dockerfile.vim
+  " dlang, from d.vim in JesseKPhillips/d.vim
   " dockerfile, from docker-compose.vim in ekalinin/Dockerfile.vim
+  " dockerfile, from Dockerfile.vim in ekalinin/Dockerfile.vim
   " elm, from elm.vim in ElmCast/elm-vim
@@ -76,4 +76,4 @@
   " ocaml, from oasis.vim in rgrinberg/vim-ocaml
-  " ocaml, from ocaml.vim in rgrinberg/vim-ocaml
   " ocaml, from ocamlbuild_tags.vim in rgrinberg/vim-ocaml
+  " ocaml, from ocaml.vim in rgrinberg/vim-ocaml
   " ocaml, from omake.vim in rgrinberg/vim-ocaml
@@ -100,4 +100,4 @@
   " reason, from reason.vim in reasonml-editor/vim-reason-plus
-  " ruby, from ruby.vim in vim-ruby/vim-ruby
   " ruby, from ruby_extra.vim in vim-ruby/vim-ruby
+  " ruby, from ruby.vim in vim-ruby/vim-ruby
   " rust, from rust.vim in rust-lang/rust.vim
@@ -120,4 +120,4 @@
   " twig, from twig.vim in lumiliet/vim-twig
-  " typescript, from typescript.vim in HerringtonDarkholme/yats.vim
   " typescript, from typescriptreact.vim in HerringtonDarkholme/yats.vim
+  " typescript, from typescript.vim in HerringtonDarkholme/yats.vim
   " v, from vlang.vim in ollykel/v-vim
```

Sorting ftdetect files before merging makes that diff much smaller and should avoid the issue in other envs going forward:

```diff
@@ -61,4 +61,4 @@
   " livescript, from ls.vim in gkz/vim-ls
-  " llvm, from llvm-lit.vim in rhysd/vim-llvm
   " llvm, from llvm.vim in rhysd/vim-llvm
+  " llvm, from llvm-lit.vim in rhysd/vim-llvm
   " llvm, from tablegen.vim in rhysd/vim-llvm
@@ -125,4 +125,4 @@
   " vcl, from vcl.vim in smerrill/vcl-vim-plugin
-  " vifm, from vifm-rename.vim in vifm/vifm.vim
   " vifm, from vifm.vim in vifm/vifm.vim
+  " vifm, from vifm-rename.vim in vifm/vifm.vim
   " vm, from velocity.vim in lepture/vim-velocity
```