### PR TITLE
Use upstream RSpec plugin

### DIFF
--- a/build
+++ b/build
@@ -269,7 +269,7 @@ PACKS="
   ragel:jneen/ragel.vim
   raml:IN3D/vim-raml
   reason:reasonml-editor/vim-reason-plus
-  rspec:sheerun/rspec.vim
+  rspec:keith/rspec.vim
   rst:marshallward/vim-restructuredtext
   ruby:vim-ruby/vim-ruby
   rust:rust-lang/rust.vim


### PR DESCRIPTION
Fixes #458. Everything looks good in Ruby files and RSpec files. Resulting diff is:
```
 README.md              |   2 +-
 after/syntax/rspec.vim |  36 ---------
 build                  |   2 +-
 ftdetect/polyglot.vim  |   7 ++
 syntax/rspec.vim       | 193 +++++++++++++++++++++++++++++++++++++++++++++++++
 5 files changed, 202 insertions(+), 38 deletions(-)
```

There is also a small change to `syntax/ruby.vim` from yesterday. Things look good to me with or without it.