### PR TITLE
Add vim-rust-syntax-ext

### DIFF
--- a/build
+++ b/build
@@ -270,6 +270,7 @@ PACKS="
   rspec:keith/rspec.vim
   rst:marshallward/vim-restructuredtext
   ruby:vim-ruby/vim-ruby
+  rust-syntax:arzg/vim-rust-syntax-ext
   rust:rust-lang/rust.vim
   sbt:derekwyatt/vim-sbt
   scala:derekwyatt/vim-scala


### PR DESCRIPTION
Hi, as the README says to keep it brief:

I chose [vim-rust-syntax-ext](https://github.com/arzg/vim-rust-syntax-ext) (I’m the author of this, full disclosure) as it improves Rust syntax highlighting IMO. It should be kept in parallel with the official rust.vim as all vim-rust-syntax-ext does is provide syntax highlighting – rust.vim is still needed for indentation, etc.