### PR TITLE
Add support for ics (icalendar) files

### DIFF
--- a/build
+++ b/build
@@ -191,6 +191,7 @@ PACKS="
   hive:zebradil/hive.vim
   html5:othree/html5.vim
   i3:mboughaba/i3config.vim
+  icalenadr:chutzpah/icalendar.vim
   idris:idris-hackers/idris-vim
   ion:vmchale/ion-vim
   javascript:pangloss/vim-javascript:_JAVASCRIPT


### PR DESCRIPTION
Picked this particular plugin some time ago, it works as intended for iCalendar files.

It's slightly better than the one it forks, but fairly simple altogether.