### PR TITLE
Enable TypeScript in ftdetect

### DIFF
--- a/ftdetect/polyglot.vim
+++ b/ftdetect/polyglot.vim
@@ -640,6 +640,7 @@ if index(g:polyglot_disabled, 'twig') == -1
 endif
 
 if index(g:polyglot_disabled, 'typescript') == -1
+  au BufNewFile,BufRead *.ts set ft=typescript
   au BufNewFile,BufRead *.tsx set ft=typescriptreact
 endif
 


### PR DESCRIPTION
Commit f3804b0892e17f309f852696491096d9048f0ef8 disabled TypeScript for .ts files.
This change restores the previous configuration.