### PR TITLE
Add Purescript commentstring local setting

### DIFF
--- a/ftplugin/purescript.vim
+++ b/ftplugin/purescript.vim
@@ -1,6 +1,7 @@
 if !exists('g:polyglot_disabled') || index(g:polyglot_disabled, 'purescript') == -1
 
 setlocal comments=s1fl:{-,mb:\ \ ,ex:-},:--\ \|,:--
+setlocal commentstring=--%s
 setlocal include=^import
 setlocal includeexpr=printf('%s.purs',substitute(v:fname,'\\.','/','g'))
 


### PR DESCRIPTION
NERDCommenter uses `commentstring`. This adds the local setting to correctly work in `purescript` files.