### PR TITLE
Add vito-c/jq.vim to `build` for jq language support

### DIFF
--- a/build
+++ b/build
@@ -197,6 +197,7 @@ PACKS="
   javascript:pangloss/vim-javascript:_JAVASCRIPT
   jenkins:martinda/Jenkinsfile-vim-syntax
   jinja:lepture/vim-jinja
+  jq:vito-c/jq.vim
   json5:GutenYe/json5.vim
   json:elzr/vim-json
   jst:briancollins/vim-jst


### PR DESCRIPTION
Hey team-

I've been happily using vito-c's [`jq.vim`](https://github.com/vito-c/jq.vim) for a while now and was hoping to add it to polyglot. As far as I can tell, this is the one jq plugin on the block; all the other "jq" results on vimawesome are for jQuery 🙃 

jq isn't a huge language, but hopefully that doesn't preclude `jq.vim`'s inclusion in the package.

Many thanks!

(P.S. here's the jq homepage: https://stedolan.github.io/jq)