### PR TITLE
add detection for rspec files

### DIFF
--- a/ftdetect/polyglot.vim
+++ b/ftdetect/polyglot.vim
@@ -546,6 +546,12 @@ if index(g:polyglot_disabled, 'ruby') == -1
   au BufNewFile,BufRead [vV]agrantfile set ft=ruby
 endif
 
+" Declared after ruby so that the more general *.rb
+" doesn't override
+if index(g:polyglot_disabled, 'rspec') == -1
+  au BufNewFile,BufRead *_spec.rb set ft=rspec
+endif
+
 if index(g:polyglot_disabled, 'rust') == -1
   au BufNewFile,BufRead *.rs set ft=rust
 endif


### PR DESCRIPTION
Standard convention for rspec files is "*_spec.rb". This is also what
rspec.vim (the syntax plugin that is pulled in) uses.
