### PR TITLE
Add jo1gi/mcfunction-vim to 'build' for mcfunction language support

### DIFF
--- a/build
+++ b/build
@@ -213,6 +213,7 @@ PACKS="
   mako:sophacles/vim-bundle-mako
   markdown:plasticboy/vim-markdown:_NOAFTER
   mathematica:voldikss/vim-mma
+  mcfunction:jo1gi/mcfunction-vim
   mdx:jxnblk/vim-mdx-js
   meson:mesonbuild/meson:_ALL:/data/syntax-highlighting/vim/
   moonscript:leafo/moonscript-vim


### PR DESCRIPTION
I've made this syntax highlighter myself and was thinking it could be added to vim-polyglot. I could not find anything else that did the same thing. Hope it is good enough :)