### PR TITLE
add missing newlines

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -279,8 +279,8 @@ def generate_ftdetect
       for extension in extensions.sort
         outer_filetype = filetype["outer_filetype"]
         if outer_filetype
-          output << "  au BufNewFile *.*.#{extension} execute \"do BufNewFile filetypedetect \" . expand(\"<afile>:r\") | #{outer_filetype}"
-          output << "  au BufReadPre *.*#{extension} execute \"do BufRead filetypedetect \" . expand(\"<afile>:r\") | #{outer_filetype}"
+          output << "  au BufNewFile *.*.#{extension} execute \"do BufNewFile filetypedetect \" . expand(\"<afile>:r\") | #{outer_filetype}\n"
+          output << "  au BufReadPre *.*#{extension} execute \"do BufRead filetypedetect \" . expand(\"<afile>:r\") | #{outer_filetype}\n"
         end
 
         if ambiguous_extensions.include?(extension)


### PR DESCRIPTION
@sheerun It looks like some missing newlines were breaking ftdetect for mako templates. This PR adds them.

On a related note, the outer filetype doesn't seem to be getting detected when the extension is simply `.mako` like it had previously. I'll poke around and see if I can figure out why that is.