### PR TITLE
add missing period to fix mako detection

### DIFF
--- a/ftdetect/polyglot.vim
+++ b/ftdetect/polyglot.vim
@@ -566,10 +566,10 @@ endif
 
 if index(g:polyglot_disabled, 'mako') == -1
   au BufNewFile *.*.mako execute "do BufNewFile filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype
-  au BufReadPre *.*mako execute "do BufRead filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype
+  au BufReadPre *.*.mako execute "do BufRead filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype
   au BufNewFile,BufRead *.mako set ft=mako
   au BufNewFile *.*.mao execute "do BufNewFile filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype
-  au BufReadPre *.*mao execute "do BufRead filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype
+  au BufReadPre *.*.mao execute "do BufRead filetypedetect " . expand("<afile>:r") | let b:mako_outer_lang = &filetype
   au BufNewFile,BufRead *.mao set ft=mako
 endif
 

--- a/scripts/build
+++ b/scripts/build
@@ -297,7 +297,7 @@ def generate_ftdetect
         outer_filetype = filetype["outer_filetype"]
         if outer_filetype
           output << "  au BufNewFile *.*.#{extension} execute \"do BufNewFile filetypedetect \" . expand(\"<afile>:r\") | #{outer_filetype}\n"
-          output << "  au BufReadPre *.*#{extension} execute \"do BufRead filetypedetect \" . expand(\"<afile>:r\") | #{outer_filetype}\n"
+          output << "  au BufReadPre *.*.#{extension} execute \"do BufRead filetypedetect \" . expand(\"<afile>:r\") | #{outer_filetype}\n"
         end
 
         if ambiguous_extensions.include?(extension)


### PR DESCRIPTION
Without the period, the autocommand for extensions like `.html.mako` was firing for `.mako` files. Filling it in fixes detection for `.mako` files.

The fancy detection for extensions like `.html.mako` seems to still be broken, but judging by the E201, I think it's also broken for the upstream mako plugin. I might poke the maintainer and see if we can find a better way to do that detection here soon.