### PR TITLE
Fix reason syntax detection

### DIFF
--- a/ftdetect/polyglot.vim
+++ b/ftdetect/polyglot.vim
@@ -237,7 +237,6 @@ if !has_key(s:disabled_packages, 'c/c++')
   au BufNewFile,BufRead *.inl setf cpp
   au BufNewFile,BufRead *.ino setf cpp
   au BufNewFile,BufRead *.ipp setf cpp
-  au BufNewFile,BufRead *.re setf cpp
   au BufNewFile,BufRead *.tcc setf cpp
   au BufNewFile,BufRead *.tpp setf cpp
 endif


### PR DESCRIPTION
Hi, 

In c1e1870a3d87850684487ddf488896d862d4039e the detection for `*.re` files was fixed, but apparently there was a regression in the latest commit.

I did the same fix and it works for me, let me know if this is a naive fix

Thanks,