### PR TITLE
Invalid characters in yaml.vim file

### DIFF
--- a/ftplugin/yaml.vim
+++ b/ftplugin/yaml.vim
@@ -19,7 +19,7 @@ setlocal comments=:# commentstring=#\ %s expandtab
 setlocal formatoptions-=t formatoptions+=croql
 
 if !exists("g:yaml_recommended_style") || g:yaml_recommended_style != 0
-  let b:undo_ftplugin ..= " sw< sts<"
+  let b:undo_ftplugin = " sw< sts<"
   setlocal shiftwidth=2 softtabstop=2
 endif
 


### PR DESCRIPTION
Unable to load any .yaml file. Removing these two spurious(?) periods
allowed plugin to work.
