### PR TITLE
Add member variable highlight for c/c++ 

### DIFF
--- a/after/syntax/c.vim
+++ b/after/syntax/c.vim
@@ -27,6 +27,13 @@ if !get(g:, 'cpp_no_function_highlight', 0)
     hi def link cUserFunction Function
 endif
 
+"  Highlight member variable names.
+if get(g:, 'cpp_member_variable_highlight', 0)
+    syn match   cCustomDot    "\." contained
+    syn match   cCustomPtr    "->" contained
+    syn match   cCustomMemVar "\(\.\|->\)\h\w*" contains=cCustomDot,cCustomPtr
+    hi def link cCustomMemVar Function
+endif
 
 " Common ANSI-standard Names
 syn keyword cAnsiName


### PR DESCRIPTION
[octol/vim-cpp-enhanced-highlight ](https://github.com/octol/vim-cpp-enhanced-highlight) is removed and in favor of [bfrg/vim-cpp-modern](https://github.com/bfrg/vim-cpp-modern) due to performance concern. However, it doesn't have the member function/variable highlighting. This PR is to bring such highlightings back.