### PR TITLE
Fix error when editing path for shebang

### DIFF
--- a/autoload/polyglot/shebang.vim
+++ b/autoload/polyglot/shebang.vim
@@ -30,7 +30,13 @@ func! s:Filetype()
 
   let [_, l:path, l:rest; __] = l:pathrest
 
-  let l:script = split(l:path, "/")[-1]
+  let l:pathparts = split(l:path, "/")
+
+  if len(l:pathparts) == 0
+    return
+  endif
+
+  let l:script = l:pathparts[-1]
 
   if l:script == "env"
     let l:argspath = matchlist(l:rest, s:r_env)


### PR DESCRIPTION
I was making a new script, and during writing the path for shebang, saw this error:

``` vim
Error detected while processing CursorHold Autocommands for "<buffer=1>"..function polyglot#shebang#Detect[1]..<SNR>78_Filetype:
line   15:
E684: list index out of range: -1
```

It's because `split(l:path, "/")` returns an empty list, so this PR fixes it.

This can be reproduced by making a new file and insert the content of the following:
``` text
#!/
```
Then go to NORMAL mode or insert a space to see the error message.