### PR TITLE
Add `cson` extension to coffee-script package

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -403,6 +403,7 @@ filetypes:
   extra_extensions:
   # 17 results: https://github.com/search?q=extension%3Acoffeekup+html&type=Code
   - coffeekup
+  - cson
   ignored_warnings:
   # Probably mistake
   - '*Cakefile'


### PR DESCRIPTION
For reference, the CoffeeScript packages for [Atom](https://github.com/atom/language-coffee-script/blob/b76b47f7d3fc04c90303af7920af034272fe8e8f/grammars/coffeescript.cson#L7) and [Sublime Text](https://github.com/aponxi/sublime-better-coffeescript/blob/0b65011a96a474ccc255612a5202d43525822556/CoffeeScript.tmLanguage#L12)
also apply for CSON files.