### PR TITLE
Removes `set incsearch` which was copied from vim-sensible

### DIFF
--- a/ftdetect/polyglot.vim
+++ b/ftdetect/polyglot.vim
@@ -3563,9 +3563,6 @@ if !has_key(g:polyglot_is_disabled, 'sensible')
 
   " Autoindent when starting new line, or using `o` or `O`.
   set autoindent
-
-  " Enable highlighted case-insensitive incremential search.
-  set incsearch
 endif
 
 " Restore 'cpoptions'


### PR DESCRIPTION
I'm one of the users who don't use `set incsearch` and therefore haven't installed the plugin `tpope/vim-sensible`.
So for me this UI related setting was a surprise and even if I can disable it, I recommend to not copying this behaviour from `vim-sensible`, as long as it is not a requirement for the core functionality of `vim-polyglot` (I would be ok with vim/nvim changing the default so I can easily disable it, but I don't want to overwrite plugins which I don't expect to change an already set option)