### PR TITLE
fix: Add commentstring for octave

### DIFF
--- a/ftplugin/octave.vim
+++ b/ftplugin/octave.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=%\ %s


### PR DESCRIPTION
Matching https://github.com/McSinyx/vim-octave/pull/3, adds `ftplugin/octave.vim` to set the `commentstring` variable.

Related to #673 #668, but does does not close.