### PR TITLE
replace array slice with while loops for Vim 7.4, closes #665

### DIFF
--- a/autoload/polyglot/init.vim
+++ b/autoload/polyglot/init.vim
@@ -3609,19 +3609,22 @@ func! s:process_rtp(rtp)
   " Then vim-polyglot
   call add(result, s:base)
   " Then all other files, until after-files
-  for path in rtp[i:len(rtp)-1]
+  while i < len(rtp)
+    let path = rtp[i]
     if match(path, '[/\\]after$') > -1
       break
     endif
     call add(result, path)
     let i = i + 1
-  endfor
+  endwhile
   " Then vim-polyglot after path
   call add(result, s:base . '/after')
   " Then all other after paths
-  for path in rtp[i:len(rtp)-1]
+  while i < len(rtp)
+    let path = rtp[i]
     call add(result, path)
-  endfor
+    let i = i + 1
+  endwhile
   " User's after directory is always last
   call add(result, a:rtp[len(a:rtp)-1])
   return result


### PR DESCRIPTION
This is a workaround that replaces array slice with while loops while iterating `rtp`.

Should fix issue https://github.com/sheerun/vim-polyglot/issues/665 that popped up for me also on CentOS/RHEL7 with vim7.4:

```
Error detected while processing function <SNR>13_process_rtp:
line   22:
E117: Unknown function: i:len
E15: Invalid expression: rtp[i:len(rtp)-1]
line   32:
E117: Unknown function: i:len
E15: Invalid expression: rtp[i:len(rtp)-1]
```

I can't test this on Vim 8 but on 7.4 it now loads just fine.
