### PR TITLE
Typescript Compiler: Issues

### DIFF
--- a/compiler/typescript.vim
+++ b/compiler/typescript.vim
@@ -22,4 +22,4 @@ endif
 
 let &l:makeprg = g:typescript_compiler_binary . ' ' . g:typescript_compiler_options . ' $* %'
 
-CompilerSet errorformat=%+A\ %#%f\ %#(%l\\\,%c):\ %m,%C%m
+CompilerSet errorformat+=%+A\ %#%f\ %#(%l\\\,%c):\ %m,%C%m


### PR DESCRIPTION
Polyglot clashes with various other TS plugins when overwriting the errorformat
instead of overwritting the errorformat we concat

issues encountered when:
using:
vim-test
neomake
and using jest to run tests to populate the quickfix list