### PR TITLE
fix(markdown): use shiftwidth() as fallback value for indent size

### DIFF
--- a/indent/markdown.vim
+++ b/indent/markdown.vim
@@ -52,7 +52,7 @@ function GetMarkdownIndent()
     if v:lnum > 2 && s:IsBlankLine(getline(v:lnum - 1)) && s:IsBlankLine(getline(v:lnum - 2))
         return 0
     endif
-    let list_ind = get(g:, "vim_markdown_new_list_item_indent", 4)
+    let list_ind = get(g:, "vim_markdown_new_list_item_indent", shiftwidth())
     " Find a non-blank line above the current line.
     let lnum = s:PrevNonBlank(v:lnum - 1)
     " At the start of the file use zero indent.


### PR DESCRIPTION
Avoid hardcoding fallback value of indent size, use `shiftwidth()` instead.