### PR TITLE
fix(test): Remove NJK from htmldjango

### DIFF
--- a/tests/extensions.vim
+++ b/tests/extensions.vim
@@ -211,7 +211,6 @@ call TestExtension("cpp", "foobar.inl", "")
 call TestExtension("htmldjango", "foobar.j2", "")
 call TestExtension("htmldjango", "foobar.jinja", "")
 call TestExtension("htmldjango", "foobar.jinja2", "")
-call TestExtension("htmldjango", "foobar.njk", "")
 
 " vim-polyglot only
 call TestExtension("blade", "test.blade.php", "")


### PR DESCRIPTION
Commit 730dcb02caab60a6ae5d8b4bdc16d290041061ec removed `.njk` as an extension for Django.  Ever since, CI has been failing because this test fails.