### PR TITLE
Issue #738: NeoVim intro screen disappears on start.

### DIFF
--- a/autoload/polyglot/init.vim
+++ b/autoload/polyglot/init.vim
@@ -2706,10 +2706,9 @@ endif
 
 func! s:Observe(fn)
   let b:PolyglotObserve = function("polyglot#" . a:fn)
-  augroup polyglot-observer
-    au!
-    au CursorHold,CursorHoldI <buffer> if (&ft == "" || &ft == "conf") | call b:PolyglotObserve() | endif
-  augroup END
+  if (&ft == "" || &ft == "conf") 
+    call b:PolyglotObserve()
+  endif
 endfunc
 
 au BufNewFile,BufRead,StdinReadPost,BufWritePost * if (&ft == "" || &ft == "conf") && expand("<afile>:e") == "" |


### PR DESCRIPTION
This commit removes the autocmd for `CursorHold, CursorHoldI` and replaces it with the basic if statement logic to set the filetype if necessary. The autocmd was causing a redraw when opening Vim without a specified file thus hiding the intro screen.

It doesn't seem like setting up an autocmd should trigger a redraw but removing this does fix the issue. I think it maintains the original intent of the function to trigger the file type to be identified. I am a novice here though.