### PR TITLE
Fixed runtimepath resolving

### DIFF
--- a/autoload/polyglot/init.vim
+++ b/autoload/polyglot/init.vim
@@ -3567,23 +3567,23 @@ if exists("did_load_filetypes") && exists("g:polyglot_disabled")
   runtime! extras/filetype.vim
 endif
 
-let s:runtime = resolve($VIMRUNTIME)
-let s:base = resolve(expand('<sfile>:p:h:h:h'))
+func! s:resolve(file) abort
+  return substitute(resolve(a:file), '\\', '/', 'g')
+endfunc
+
+let s:runtime = s:resolve($VIMRUNTIME)
+let s:base = s:resolve(expand('<sfile>:p:h:h:h'))
 
 func! s:process_rtp(rtp)
   " Remove vim-polyglot from paths and make everything absolute
-  let rtp = []
-  for path in a:rtp[1:-2]
-    let abspath = resolve(path)
-    if stridx(abspath, s:base) != 0
-      call add(rtp, abspath)
-    endif
-  endfor
+  let rtp = filter(map(copy(a:rtp[1:-2]), '[s:resolve(v:val), v:val]'),
+        \ 'stridx(v:val[0], s:base) != 0')
+  " User's directory is always first
   let result = [a:rtp[0]]
   " Then all other stuff (until vimruntime)
   let i = 0
-  for path in rtp[0:len(rtp)-1]
-    if path == s:runtime
+  for [abspath, path] in rtp[0:len(rtp)-1]
+    if abspath == s:runtime
       break
     endif
     call add(result, path)
@@ -3593,8 +3593,8 @@ func! s:process_rtp(rtp)
   call add(result, s:base)
   " Then all other files, until after-files
   while i < len(rtp)
-    let path = rtp[i]
-    if match(path, '[/\\]after$') > -1
+    let [abspath, path] = rtp[i]
+    if match(abspath, '/after$') > -1
       break
     endif
     call add(result, path)
@@ -3604,7 +3604,7 @@ func! s:process_rtp(rtp)
   call add(result, s:base . '/after')
   " Then all other after paths
   while i < len(rtp)
-    let path = rtp[i]
+    let [_, path] = rtp[i]
     call add(result, path)
     let i = i + 1
   endwhile


### PR DESCRIPTION
Vim-polyglot changes `runtimepath`, but...

* In Windows, `resolve()` does not do full normalization.
  Therefore, the path of vim-polyglot is not filtered, and registered more than once.
  ex.) `runtimepath` =>
  ```
  C:\Users\alice\.config\vim
  C:/Users/alice/.vimplugins/vim-polyglot
  C:\Users\alice\.vimplugins\vim-polyglot
  C:\tools\vim\vim82
  C:\Users\alice\.vimplugins\vim-polyglot/after
  C:/Users/alice/.vimplugins/vim-polyglot/after
  C:\Users\alice\.config\vim/after
  ```
  Fix) Substitute `\` to `/` after resolved.
* Rewriting the runtimepath has too many side effects.
  ex.) Conflicts occur when the plugin-manager manages the paths.
  Fix) Resolved paths are used only for matching, and the original path representation is preserved.