### PR TITLE
Match just filenames case-insensitively

### DIFF
--- a/autoload/polyglot/init.vim
+++ b/autoload/polyglot/init.vim
@@ -186,7 +186,7 @@ if !has_key(g:polyglot_is_disabled, 'nftables')
 endif
 
 if !has_key(g:polyglot_is_disabled, 'just')
-  au BufNewFile,BufRead *.just,justfile setf just
+  au BufNewFile,BufRead *.just,\cjustfile setf just
 endif
 
 if !has_key(g:polyglot_is_disabled, 'sway')

--- a/autoload/polyglot/sleuth.vim
+++ b/autoload/polyglot/sleuth.vim
@@ -267,7 +267,7 @@ let s:globs = {
   \ 'jsp': '*.jsp',
   \ 'jst': '*.ejs,*.ect,*.jst',
   \ 'julia': '*.jl',
-  \ 'just': '*.just,justfile',
+  \ 'just': '*.just,\cjustfile',
   \ 'kconfig': 'Kconfig,Kconfig.debug,Kconfig.*',
   \ 'kivy': '*.kv',
   \ 'kix': '*.kix',

--- a/packages.yaml
+++ b/packages.yaml
@@ -5510,7 +5510,7 @@ remote: NoahTheDuke/vim-just
 filetypes:
 - name: just
   patterns:
-  - pattern: 'justfile,*.just'
+  - pattern: '\cjustfile,*.just'
     description: 'Just a task runner (https://github.com/casey/just)'
 ---
 name: nftables


### PR DESCRIPTION
This PR offers case-insensitive support for `just` files.