### PR TITLE
Fix splash

### DIFF
--- a/autoload/polyglot/init.vim
+++ b/autoload/polyglot/init.vim
@@ -2676,7 +2676,7 @@ func! s:Observe(fn)
   let b:PolyglotObserve = function("polyglot#" . a:fn)
   augroup polyglot-observer
     au!
-    au CursorHold,CursorHoldI <buffer> if (&ft == "" || &ft == "conf") | call b:PolyglotObserve() | endif
+    au CursorHold,CursorHoldI <buffer> if ((&ft == "" && getline(1,'$') != ['']) || &ft == "conf") | call b:PolyglotObserve() | endif
   augroup END
 endfunc
 


### PR DESCRIPTION
It seems the calling of `function("polyglot#" . "shebang#Detect")` seems to cause the splash screen to disappear when opening a fresh vim.

This change fixes this by not calling it if the file is empty.

How I tested:
1. `vim` 
2. wait about a second
3. Before: the splash screen would disappear, after: the splash screen stays