### PR TITLE
Update the zinit syntax repository

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -1518,7 +1518,7 @@ filetypes:
   - '*/etc/zprofile'
 ---
 name: zinit
-remote: zinit-zsh/zplugin-vim-syntax
+remote: zdharma-continuum/zinit-vim-syntax
 # just adds to zsh filetype
 filetypes: []
 ---


### PR DESCRIPTION
seems like the remote zinit-zsh/zplugin-vim-syntax has been removed and that's why the ./scripts/build breaks with following error

```
gzip: stdin: unexpected end of file                                                                                     
tar: Child returned status 1                                                                                            
tar: Error is not recoverable: exiting now                                                                              
./scripts/build:531:in `block in extract': No files in: zinit (StandardError) 
        from ./scripts/build:493:in `map'                                                                               
        from ./scripts/build:493:in `extract'                                                                           
        from ./scripts/build:923:in `<main>'                                                                            
```
