### PR TITLE
Use 0az/vim-caddyfile fork

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -357,11 +357,13 @@ filetypes:
   - '*enlightenment/*.cfg'
 ---
 name: caddyfile
-remote: isobit/vim-caddyfile
+remote: 0az/vim-caddyfile
 filetypes:
 - name: caddyfile
   filenames:
   - Caddyfile
+  - Caddyfile.*
+  - *.Caddyfile
 ---
 name: cpp-modern
 remote: bfrg/vim-cpp-modern


### PR DESCRIPTION
The 0az/vim-caddyfile fork integrates changes from all known vim-caddyfile forks.

It additionally fixes one syntax bug.