### PR TITLE
Check if TestFiletypeFuncs exists before defining it

### DIFF
--- a/extras/filetype.vim
+++ b/extras/filetype.vim
@@ -2506,17 +2506,20 @@ endif
 " Function called for testing all functions defined here.  These are
 " script-local, thus need to be executed here.
 " Returns a string with error messages (hopefully empty).
-func! TestFiletypeFuncs(testlist)
-  let output = ''
-  for f in a:testlist
-    try
-      exe f
-    catch
-      let output = output . "\n" . f . ": " . v:exception
-    endtry
-  endfor
-  return output
-endfunc
+" Check if function exists first. See https://github.com/vim/vim/issues/9890
+if !exists("*TestFiletypeFuncs")
+  func! TestFiletypeFuncs(testlist)
+    let output = ''
+    for f in a:testlist
+      try
+        exe f
+      catch
+        let output = output . "\n" . f . ": " . v:exception
+      endtry
+    endfor
+    return output
+  endfunc
+endif
 
 " Restore 'cpoptions'
 let &cpo = s:cpo_save


### PR DESCRIPTION
Fixes #783

This appears to fix the issue for me. Not sure if this is the best way to do it. Happy to rework the PR.

https://github.com/vim/vim/issues/9890 is also helpful for context.