### PR TITLE
Add missing filetypes for go.sum and go.work

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -689,6 +689,9 @@ filetypes:
 - name: gosum
   filenames:
   - go.sum
+- name: gowork
+  filenames:
+  - go.work
 - name: gohtmltmpl
   extensions:
   - tmpl

--- a/packages.yaml
+++ b/packages.yaml
@@ -686,6 +686,9 @@ filetypes:
 - name: gomod
   filenames:
   - go.mod
+- name: gosum
+  filenames:
+  - go.sum
 - name: gohtmltmpl
   extensions:
   - tmpl


### PR DESCRIPTION
Add missing filetypes for [go.sum](https://github.com/fatih/vim-go/blob/master/syntax/gosum.vim) and [go.work](https://github.com/fatih/vim-go/blob/master/syntax/gowork.vim) to the `packages.yaml` file

I did run `make build` to confirm it works. But since it created quite a lot of unrelated changes I did not push it into the PR.