### PR TITLE
Rename `TestFiletypeFuncs` to avoid name collision

### DIFF
--- a/extras/filetype.vim
+++ b/extras/filetype.vim
@@ -2506,7 +2506,7 @@ endif
 " Function called for testing all functions defined here.  These are
 " script-local, thus need to be executed here.
 " Returns a string with error messages (hopefully empty).
-func! TestFiletypeFuncs(testlist)
+func! TestPolyglotFiletypeFuncs(testlist)
   let output = ''
   for f in a:testlist
     try

--- a/scripts/build
+++ b/scripts/build
@@ -902,6 +902,7 @@ def generate_fallback
   filetype_content.gsub!(/^au StdinReadPost \* .+?runtime!.+?endif/m) {}
   filetype_content.gsub!(/^au filetypedetect BufNewFile,BufRead,StdinReadPost \*\n.+?endif/m) {}
   filetype_content.gsub!("dist#ft#", "polyglot#ft#")
+  filetype_content.gsub!("TestFiletypeFuncs", "TestPolyglotFiletypeFuncs")
   File.write('extras/filetype.vim', filetype_content)
   File.write('extras/menu.vim', File.read('tmp/vim/vim-v8.2.4274/runtime/menu.vim'))
 


### PR DESCRIPTION
Fixes #783.