### PR TITLE
Split `nimBuiltin` group + other minor fixes

### DIFF
--- a/syntax/nim.vim
+++ b/syntax/nim.vim
@@ -14,6 +14,12 @@ endif
 if !exists('nim_highlight_numbers')
   let nim_highlight_numbers = 1
 endif
+if !exists('nim_highlight_types')
+  let nim_highlight_types = 1
+endif
+if !exists('nim_highlight_identifiers')
+  let nim_highlight_identifiers = 1
+endif
 if !exists('nim_highlight_builtins')
   let nim_highlight_builtins = 1
 endif
@@ -29,6 +35,8 @@ endif
 
 if exists('nim_highlight_all')
   let nim_highlight_numbers      = 1
+  let nim_highlight_types        = 1
+  let nim_highlight_identifiers  = 1
   let nim_highlight_builtins     = 1
   let nim_highlight_exceptions   = 1
   let nim_highlight_space_errors = 1
@@ -37,37 +45,30 @@ endif
 
 syn region nimBrackets       contained extend keepend matchgroup=Bold start=+\(\\\)\@<!\[+ end=+]\|$+ skip=+\\\s*$\|\(\\\)\@<!\\]+ contains=@tclCommandCluster
 
-syn keyword nimKeyword       addr and as asm atomic
+syn keyword nimKeyword       addr as asm atomic
 syn keyword nimKeyword       bind block break
-syn keyword nimKeyword       case cast concept const continue converter
-syn keyword nimKeyword       defer discard distinct div do
-syn keyword nimKeyword       elif else end enum except export
-syn keyword nimKeyword       finally for from
-syn keyword nimKeyword       generic
-syn keyword nimKeyword       if import in include interface is isnot iterator
-syn keyword nimKeyword       let
-syn keyword nimKeyword       mixin using mod
-syn keyword nimKeyword       nil not notin
-syn keyword nimKeyword       object of or out
+syn keyword nimKeyword       cast concept const continue converter
+syn keyword nimKeyword       defer discard distinct do
+syn keyword nimKeyword       generic object end enum export
+syn keyword nimKeyword       finally from mixin using
+syn keyword nimKeyword       import include interface isnot iterator
 syn keyword nimKeyword       proc func method macro template nextgroup=nimFunction skipwhite
-syn keyword nimKeyword       ptr
-syn keyword nimKeyword       raise ref return
-syn keyword nimKeyword       shared shl shr static
-syn keyword nimKeyword       try tuple type
-syn keyword nimKeyword       var vtref vtptr
-syn keyword nimKeyword       when while with without
-syn keyword nimKeyword       xor
-syn keyword nimKeyword       yield
+syn keyword nimKeyword       raise ref return ptr
+syn keyword nimKeyword       shared static
+syn keyword nimKeyword       try except tuple type
+syn keyword nimKeyword       let var vtref vtptr
+syn keyword nimKeyword       with without
 
 syn match   nimFunction      "[a-zA-Z_][a-zA-Z0-9_]*" contained
 syn match   nimClass         "[a-zA-Z_][a-zA-Z0-9_]*" contained
 syn keyword nimRepeat        for while
-syn keyword nimConditional   if elif else case of
-syn keyword nimOperator      and in is not or xor shl shr div
+syn keyword nimConditional   when if elif else case of
+syn keyword nimOperator      not and or xor in notin is div mod shl shr
 syn match   nimComment       "#.*$" contains=nimTodo,@Spell
 syn region  nimComment       start="#\[" end="\]#" contains=nimTodo,@Spell
 syn keyword nimTodo          TODO FIXME XXX contained
 syn keyword nimBoolean       true false
+syn keyword nimConstant      nil
 
 
 " Strings
@@ -98,25 +99,31 @@ if nim_highlight_numbers == 1
   unlet s:dec_num s:int_suf s:float_suf s:exp
 endif
 
+if nim_highlight_types == 1
+  syn keyword nimType int int8 int16 int32 int64 uint uint8 uint16 uint32 uint64 float float32 float64
+  syn keyword nimType bool void chr char string cstring pointer range array openarray varargs
+  syn keyword nimType Byte Natural Positive Conversion BiggestInt BiggestFloat
+  syn keyword nimType cchar cschar cshort cint csize cuchar cushort
+  syn keyword nimType clong clonglong cfloat cdouble clongdouble cuint culong culonglong
+endif
+
+if nim_highlight_identifiers == 1
+  syn keyword nimIdentifier stdin stdout stderr
+  syn keyword nimIdentifier typedesc typed untyped
+  syn keyword nimIdentifier Inf NegInf NaN
+endif
+
 if nim_highlight_builtins == 1
   " builtin functions, types and objects, not really part of the syntax
-  syn keyword nimBuiltin int int8 int16 int32 int64 uint uint8 uint16 uint32 uint64 float float32 float64
-  syn keyword nimBuiltin bool void chr char string cstring pointer range array openarray openArray seq varargs varArgs
-  syn keyword nimBuiltin set Byte Natural Positive Conversion
-  syn keyword nimBuiltin BiggestInt BiggestFloat cchar cschar cshort cint csize cuchar cushort
-  syn keyword nimBuiltin clong clonglong cfloat cdouble clongdouble cuint culong culonglong cchar
-  syn keyword nimBuiltin CompileDate CompileTime nimversion nimVersion nimmajor nimMajor
-  syn keyword nimBuiltin nimminor nimMinor nimpatch nimPatch cpuendian cpuEndian hostos hostOS hostcpu hostCPU inf
-  syn keyword nimBuiltin neginf nan QuitSuccess QuitFailure dbglinehook dbgLineHook stdin
-  syn keyword nimBuiltin stdout stderr defined new high low sizeof succ pred
+  syn keyword nimBuiltin CompileDate CompileTime nimversion nimVersion nimmajor nimMajor nimminor nimMinor
+  syn keyword nimBuiltin nimpatch nimPatch cpuendian cpuEndian hostos hostOS hostcpu hostCPU
+  syn keyword nimBuiltin addquitproc addQuitProc QuitSuccess QuitFailure dbglinehook dbgLineHook
+  syn keyword nimBuiltin defined new high low sizeof succ pred
   syn keyword nimBuiltin inc dec newseq newSeq len incl excl card ord chr ze ze64
   syn keyword nimBuiltin tou8 toU8 tou16 toU16 tou32 toU32 abs min max add repr
-  syn match   nimBuiltin "\<contains\>"
   syn keyword nimBuiltin tofloat toFloat tobiggestfloat toBiggestFloat toint toInt tobiggestint toBiggestInt
-  syn keyword nimBuiltin addquitproc addQuitProc
-  syn keyword nimBuiltin copy setlen setLen newstring newString zeromem zeroMem copymem copyMem movemem moveMem
+  syn keyword nimBuiltin copy set setlen setLen newstring newString zeromem zeroMem copymem copyMem movemem moveMem
   syn keyword nimBuiltin equalmem equalMem alloc alloc0 realloc dealloc assert
-  syn keyword nimBuiltin typedesc typed untyped stmt expr
   syn keyword nimBuiltin echo swap getrefcount getRefcount getcurrentexception getCurrentException Msg
   syn keyword nimBuiltin getoccupiedmem getOccupiedMem getfreemem getFreeMem gettotalmem getTotalMem isnil isNil seqtoptr seqToPtr
   syn keyword nimBuiltin find pop GC_disable GC_enable GC_fullCollect
@@ -129,6 +136,7 @@ if nim_highlight_builtins == 1
   syn keyword nimBuiltin writechars writeChars writebuffer writeBuffer setfilepos setFilePos getfilepos getFilePos
   syn keyword nimBuiltin filehandle fileHandle countdown countup items lines
   syn keyword nimBuiltin FileMode File RootObj FileHandle ByteAddress Endianness
+  syn match   nimBuiltin "\<contains\>"
 endif
 
 if nim_highlight_exceptions == 1
@@ -153,7 +161,7 @@ if nim_highlight_space_errors == 1
   syn match   nimSpaceError   display "\t"
 endif
 
-if nim_highlight_special_vars
+if nim_highlight_special_vars == 1
   syn keyword nimSpecialVar result
 endif
 
@@ -169,41 +177,51 @@ if v:version >= 508 || !exists('did_nim_syn_inits')
     command -nargs=+ HiLink hi def link <args>
   endif
 
-  " The default methods for highlighting.  Can be overridden later
-  HiLink nimBrackets       Operator
-  HiLink nimKeyword	      Keyword
-  HiLink nimFunction	    	Function
-  HiLink nimConditional	  Conditional
-  HiLink nimRepeat		      Repeat
-  HiLink nimString		      String
-  HiLink nimRawString	    String
-  HiLink nimBoolean        Boolean
-  HiLink nimEscape		      Special
-  HiLink nimOperator		    Operator
-  HiLink nimPreCondit	    PreCondit
-  HiLink nimComment		    Comment
-  HiLink nimTodo		        Todo
-  HiLink nimDecorator	    Define
-  HiLink nimSpecialVar	    Identifier
-  
+  " The default methods for highlighting. Can be overridden later
+  HiLink nimBrackets      Operator
+  HiLink nimKeyword       Keyword
+  HiLink nimFunction      Function
+  HiLink nimConditional   Conditional
+  HiLink nimRepeat        Repeat
+  HiLink nimString        String
+  HiLink nimRawString     String
+  HiLink nimBoolean       Boolean
+  HiLink nimEscape        Special
+  HiLink nimOperator      Operator
+  HiLink nimPreCondit     PreCondit
+  HiLink nimComment       Comment
+  HiLink nimTodo          Todo
+  HiLink nimDecorator     Define
+
   if nim_highlight_numbers == 1
-    HiLink nimNumber	Number
+    HiLink nimNumber Number
   endif
-  
+
+  if nim_highlight_types == 1
+    HiLink nimType Type
+  endif
+
+  if nim_highlight_identifiers == 1
+    HiLink nimIdentifier Identifier
+  endif
+
   if nim_highlight_builtins == 1
-    HiLink nimBuiltin	Number
+    HiLink nimBuiltin Function
   endif
-  
+
   if nim_highlight_exceptions == 1
     HiLink nimException	Exception
   endif
-  
+
   if nim_highlight_space_errors == 1
-    HiLink nimSpaceError	Error
+    HiLink nimSpaceError Error
+  endif
+
+  if nim_highlight_special_vars == 1
+    HiLink nimSpecialVar Identifier
   endif
 
   delcommand HiLink
 endif
 
 let b:current_syntax = 'nim'
-


### PR DESCRIPTION
Splitting builtin group (`nimBuiltin`) into types (`nimType`), identifiers (`nimIdentifier`) and functions (left as `nimBuiltin`), adding appropriate higlight for each of them and fixing various minor issues.