### PR TITLE
Fix changed function name for distinguishing *.frm between vb and form

### DIFF
--- a/autoload/polyglot/init.vim
+++ b/autoload/polyglot/init.vim
@@ -3301,7 +3301,7 @@ au BufRead,BufNewFile *.hw,*.module,*.pkg
 	\ endif
 
 " Visual Basic (also uses *.bas) or FORM
-au BufNewFile,BufRead *.frm			call polyglot#ft#FTVB("form")
+au BufNewFile,BufRead *.frm			call polyglot#ft#FTfrm()
 
 " WEB (*.web is also used for Winbatch: Guess, based on expecting "%" comment
 " lines in a WEB file).


### PR DESCRIPTION
For *.frm, change call polyglot#ft#FTVB(form) to polyglot#ft#FTfrm() since former doesn't exist and latter seems to be what we're looking for.