### PR TITLE
Update gleam syntax to match last version

### DIFF
--- a/syntax/gleam.vim
+++ b/syntax/gleam.vim
@@ -12,32 +12,67 @@ let b:current_syntax = "gleam"
 
 " Keywords
 syntax keyword gleamKeyword
-  \ module import pub external
+  \ import pub panic use
   \ type let as if else todo const
-  \ case assert tuple try opaque
+  \ case assert try opaque
 highlight link gleamKeyword Keyword
 
 " Function definition
 syntax keyword gleamDef fn nextgroup=gleamFunctionDef skipwhite skipempty
 highlight link gleamDef Keyword
 
-syntax match gleamFunctionDef "[a-z_-][0-9a-z_-]*" contained skipwhite skipnl
+syntax match gleamFunctionDef "[a-z][a-z0-9_]*\ze\s*(" skipwhite skipnl
+highlight link gleamFunctionDef Function
 highlight link gleamFunctionDef Function
 
-" Int
-syntax match gleamInt '\<[0-9][0-9_]*\>'
+" Number
+"" Int
+syntax match gleamInt '\<\(0*[1-9][0-9_]*|0\)\>'
 highlight link gleamInt Number
 
-" Float
-syntax match gleamFloat '\<[0-9][0-9_]*\.[0-9_]*\>'
+"" Binary
+syntax match gleamBinary '\<0[bB]\(0*1[01_]*\|0\)\>'
+highlight link gleamBinary Number
+
+"" Octet
+syntax match gleamOctet '\<0[oO]\(0*[1-7][0-7_]*\|0\)\>'
+highlight link gleamOctet Number
+
+"" Hexadecimal
+syntax match gleamHexa '\<0[xX]\(0*[1-9a-zA-Z][0-9a-zA-Z_]*\|0\)\>'
+highlight link gleamHexa Number
+
+"" Float
+syntax match gleamFloat '\(0*[1-9][0-9_]*\|0\)\.\(0*[1-9][0-9_]*\|0\)\=\(e-\=0*[1-9][0-9_]*\)\='
 highlight link gleamFloat Float
 
 " Operators
-syntax match gleamOperator "\([-!#$%`&\*\+./<=>@\\^|~:]\|\<\>\)"
+"" Basic
+syntax match gleamOperator "[-+/*]\.\=\|[%=]"
 highlight link gleamOperator Operator
 
+"" Arrows + Pipeline
+syntax match gleamOperator "<-\|[-|]>"
+highlight link gleamOperator Operator
+
+"" Bool
+syntax match gleamOperator "&&\|||"
+highlight link gleamOperator Operator
+
+"" Comparison
+syntax match gleamOperator "[<>]=\=\.\=\|[=!]="
+highlight link gleamOperator Operator
+
+"" Misc
+syntax match gleamOperator "\.\.\|<>\||"
+highlight link gleamOperator Operator
+
+" Values
+syntax keyword gleamValues True False Nil
+highlight def link gleamValues Boolean
+
 " Type
-syntax match gleamType "\([a-z]\)\@<![A-Z]\w*"
+syntax match gleamType "\<[A-Z][a-zA-Z0-9]*\>"
 highlight link gleamType Identifier
 
 " Comments
@@ -54,5 +89,5 @@ highlight link gleamString String
 highlight link gleamStringModifier Special
 
 " Attribute
-syntax match gleamAttribute "#[a-z][a-z_]*"
+syntax match gleamAttribute "@[a-z][a-z_]*"
 highlight link gleamAttribute PreProc


### PR DESCRIPTION
Fixes :
- Outdated regexes
- Keywords invalid
- Add syntax highlighting for 'Nil'

All fixes and regexes were validated by gleam maintainer and merged to the gleam.vim plugin.
See https://github.com/gleam-lang/gleam.vim/pull/14