### PR TITLE
Add Java sh-bang support

### DIFF
--- a/autoload/polyglot/shebang.vim
+++ b/autoload/polyglot/shebang.vim
@@ -197,6 +197,10 @@ func! polyglot#shebang#VimDetect()
     elseif name =~# 'wml'
       set ft=wml | return
 
+      " Since JEP-330, java supports sh-bang
+    elseif name =~# 'java'
+      set ft=java | return
+
       " Scheme scripts
     elseif name =~# 'scheme'
       set ft=scheme | return


### PR DESCRIPTION
With Java 11's [JEP-330](https://openjdk.org/jeps/330), java supports sh-bang lines.

This only works on files without a `.java` extension

>[if the file doesn't have a .java extension, and] the first line begins with #!, then the contents of that line up to but not including the first newline are ignored when determining the source code to be passed to the compiler